### PR TITLE
Removing dependencies from typescript package

### DIFF
--- a/lib/template/typescript_source.rb
+++ b/lib/template/typescript_source.rb
@@ -1,7 +1,5 @@
 class Template::TypescriptSource < Template::Base
   CONTENT = <<-CONTENT
-    |import { parse as parseUrl } from "url"
-    |
     |import {
     |  <%= callback_props_group_type_name(:base) %>,
     |  Metadata,
@@ -86,7 +84,8 @@ class Template::TypescriptSource < Template::Base
     | * @throws {PostMessageFieldDecodeError}
     | */
     |function buildPayloadFromUrl(urlString: string): Payload {
-    |  const url = parseUrl(urlString, true)
+    |  const { parse } = require("url")
+    |  const url = parse(urlString, true)
     |
     |  const namespace = url.host || ""
     |  const action = (url.pathname || "").substring(1)

--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -32,7 +32,14 @@ dispatchConnectLocationChangeEvent("mx://connect/memberDeleted?metadata=...", {
 
 This package does not have any depedencies with the exception of the `url`
 package, which you may need if you're parsing post message events from URL
-change events. To install it:
+change events.
+
+The React Native SDK needs this package and has it as a dependency, but the Web
+SDK won't and we shouldn't install or import it. This allows us to keep both
+SDKs happy.
+
+To install `url` in your project so you can parse post messages in location
+change events:
 
 ```text
 npm install --save url

--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -27,3 +27,13 @@ dispatchConnectLocationChangeEvent("mx://connect/memberDeleted?metadata=...", {
   }
 })
 ```
+
+## Dependencies
+
+This package does not have any depedencies with the exception of the `url`
+package, which you may need if you're parsing post message events from URL
+change events. To install it:
+
+```text
+npm install --save url
+```

--- a/packages/typescript/package-lock.json
+++ b/packages/typescript/package-lock.json
@@ -8,9 +8,6 @@
       "name": "@mxenabled/widget-post-message-definitions",
       "version": "1.0.5",
       "license": "MIT",
-      "dependencies": {
-        "url": "^0.11.0"
-      },
       "devDependencies": {
         "@types/jest": "^27.4.1",
         "@types/node": "^17.0.21",
@@ -4252,20 +4249,6 @@
       "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
       "dev": true
     },
-    "node_modules/punycode": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
-    },
-    "node_modules/querystring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
-      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
-      "engines": {
-        "node": ">=0.4.x"
-      }
-    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -4905,15 +4888,6 @@
       "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/url": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
-      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
-      "dependencies": {
-        "punycode": "1.3.2",
-        "querystring": "0.2.0"
       }
     },
     "node_modules/v8-compile-cache": {
@@ -8374,16 +8348,6 @@
       "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
       "dev": true
     },
-    "punycode": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
-    },
-    "querystring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
-    },
     "queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -8823,15 +8787,6 @@
           "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
           "dev": true
         }
-      }
-    },
-    "url": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
-      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
-      "requires": {
-        "punycode": "1.3.2",
-        "querystring": "0.2.0"
       }
     },
     "v8-compile-cache": {

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -14,9 +14,6 @@
     "type": "git",
     "url": "https://github.com/mxenabled/widget-post-message-definitions.git"
   },
-  "dependencies": {
-    "url": "^0.11.0"
-  },
   "devDependencies": {
     "@types/jest": "^27.4.1",
     "@types/node": "^17.0.21",
@@ -63,6 +60,9 @@
         "double"
       ],
       "no-trailing-spaces": "error",
+      "@typescript-eslint/no-var-requires": [
+        "off"
+      ],
       "@typescript-eslint/no-unused-vars": [
         "error",
         {

--- a/packages/typescript/src/generated.ts
+++ b/packages/typescript/src/generated.ts
@@ -7,8 +7,6 @@
  * project.
  */
 
-import { parse as parseUrl } from "url"
-
 import {
   BasePostMessageCallbackProps,
   Metadata,
@@ -486,7 +484,8 @@ function buildPayload(type: Type, metadata: Metadata): Payload {
  * @throws {PostMessageFieldDecodeError}
  */
 function buildPayloadFromUrl(urlString: string): Payload {
-  const url = parseUrl(urlString, true)
+  const { parse } = require("url")
+  const url = parse(urlString, true)
 
   const namespace = url.host || ""
   const action = (url.pathname || "").substring(1)


### PR DESCRIPTION
Making the `url` package an optional dependency. The React Native SDK will need this package and currently has it as a dependency, but the Web SDK won't and we shouldn't install or import it. This allows us to keep both SDKs happy.