### PR TITLE
Splitting message dispatch logic

### DIFF
--- a/lib/template/typescript_source.rb
+++ b/lib/template/typescript_source.rb
@@ -159,22 +159,29 @@ class Template::TypescriptSource < Template::Base
     | * @throws {unknown}
     | */
     |export function <%= dispatch_location_change_function_name(:widget) %>(url: string, callbacks: <%= callback_props_group_type_name(:widget) %>) {
-    |  callbacks.onMessage?.(url)
-    |
     |  try {
+    |    <%= dispatch_location_change_catch_all_function_name %>(url, callbacks)
     |    const payload = buildPayloadFromUrl(url)
-    |    switch (payload.type) {
-    |      <%- (generic_post_message_definitions + entity_post_message_definitions).each do |post_message| -%>
-    |      case <%= qualified_enum_key(post_message) %>:
-    |        callbacks.<%= callback_function_name(post_message) %>?.(payload)
-    |        break
-    |
-    |      <%- end -%>
-    |      default:
-    |        throw new PostMessageUnknownTypeError(payload.type)
-    |    }
+    |    <%= dispatch_internal_message_function_name(:widget) %>(payload, callbacks)
     |  } catch (error) {
     |    dispatchError(url, error, callbacks)
+    |  }
+    |}
+    |
+    |function <%= dispatch_location_change_catch_all_function_name %>(url: string, callbacks: <%= callback_props_group_type_name(:widget) %>) {
+    |  callbacks.onMessage?.(url)
+    |}
+    |
+    |function <%= dispatch_internal_message_function_name(:widget) %>(payload: Payload, callbacks: <%= callback_props_group_type_name(:widget) %>) {
+    |  switch (payload.type) {
+    |    <%- (generic_post_message_definitions + entity_post_message_definitions).each do |post_message| -%>
+    |    case <%= qualified_enum_key(post_message) %>:
+    |      callbacks.<%= callback_function_name(post_message) %>?.(payload)
+    |      break
+    |
+    |    <%- end -%>
+    |    default:
+    |      throw new PostMessageUnknownTypeError(payload.type)
     |  }
     |}
     |
@@ -188,28 +195,31 @@ class Template::TypescriptSource < Template::Base
     | * @throws {unknown}
     | */
     |export function <%= dispatch_location_change_function_name(subgroup) %>(url: string, callbacks: <%= callback_props_group_type_name(subgroup) %>) {
-    |  callbacks.onMessage?.(url)
-    |
     |  try {
+    |    <%= dispatch_location_change_catch_all_function_name %>(url, callbacks)
     |    const payload = buildPayloadFromUrl(url)
-    |    switch (payload.type) {
-    |      <%- (generic_post_message_definitions + entity_post_message_definitions).each do |post_message| -%>
-    |      case <%= qualified_enum_key(post_message) %>:
-    |        callbacks.<%= callback_function_name(post_message) %>?.(payload)
-    |        break
-    |
-    |      <%- end -%>
-    |      <%- post_messages.each do |post_message| -%>
-    |      case <%= qualified_enum_key(post_message) %>:
-    |        callbacks.<%= callback_function_name(post_message) %>?.(payload)
-    |        break
-    |
-    |      <%- end -%>
-    |      default:
-    |        throw new PostMessageUnknownTypeError(payload.type)
-    |    }
+    |    <%= dispatch_internal_message_function_name(subgroup) %>(payload, callbacks)
     |  } catch (error) {
     |    dispatchError(url, error, callbacks)
+    |  }
+    |}
+    |
+    |function <%= dispatch_internal_message_function_name(subgroup) %>(payload: Payload, callbacks: <%= callback_props_group_type_name(subgroup) %>) {
+    |  switch (payload.type) {
+    |    <%- (generic_post_message_definitions + entity_post_message_definitions).each do |post_message| -%>
+    |    case <%= qualified_enum_key(post_message) %>:
+    |      callbacks.<%= callback_function_name(post_message) %>?.(payload)
+    |      break
+    |
+    |    <%- end -%>
+    |    <%- post_messages.each do |post_message| -%>
+    |    case <%= qualified_enum_key(post_message) %>:
+    |      callbacks.<%= callback_function_name(post_message) %>?.(payload)
+    |      break
+    |
+    |    <%- end -%>
+    |    default:
+    |      throw new PostMessageUnknownTypeError(payload.type)
     |  }
     |}
     |<%- end -%>
@@ -347,13 +357,34 @@ class Template::TypescriptSource < Template::Base
 
   # @example
   #
+  #   dispatch_location_change_catch_all_function_name
+  #   # => "dispatchLocationChangeCatchAll"
+  #
+  # @return [String]
+  def dispatch_location_change_catch_all_function_name
+    "dispatchLocationChangeCatchAll"
+  end
+  # @example
+  #
   #   dispatch_location_change_function_name(:generic)
-  #   # => "dispatchWidgetPostMessage"
+  #   # => "dispatchWidgetLocationChange"
   #
   # @param [String] group
   # @return [String]
   def dispatch_location_change_function_name(group)
     "dispatch#{normalize_keywords(group.to_s.classify)}LocationChangeEvent"
+  end
+
+
+  # @example
+  #
+  #   dispatch_internal_message_function_name(:generic)
+  #   # => "dispatchWidgetInternalMessage"
+  #
+  # @param [String] group
+  # @return [String]
+  def dispatch_internal_message_function_name(group)
+    "dispatch#{normalize_keywords(group.to_s.classify)}InternalMessage"
   end
 
   # @example

--- a/lib/template/typescript_source.rb
+++ b/lib/template/typescript_source.rb
@@ -368,7 +368,7 @@ class Template::TypescriptSource < Template::Base
   # @example
   #
   #   dispatch_location_change_function_name(:generic)
-  #   # => "dispatchWidgetLocationChange"
+  #   # => "dispatchWidgetLocationChangeEvent"
   #
   # @param [String] group
   # @return [String]

--- a/lib/template/typescript_source.rb
+++ b/lib/template/typescript_source.rb
@@ -364,6 +364,7 @@ class Template::TypescriptSource < Template::Base
   def dispatch_location_change_catch_all_function_name
     "dispatchLocationChangeCatchAll"
   end
+
   # @example
   #
   #   dispatch_location_change_function_name(:generic)
@@ -374,7 +375,6 @@ class Template::TypescriptSource < Template::Base
   def dispatch_location_change_function_name(group)
     "dispatch#{normalize_keywords(group.to_s.classify)}LocationChangeEvent"
   end
-
 
   # @example
   #

--- a/packages/typescript/src/generated.ts
+++ b/packages/typescript/src/generated.ts
@@ -571,32 +571,39 @@ function dispatchError(url: string, error: unknown, callbacks: WidgetPostMessage
  * @throws {unknown}
  */
 export function dispatchWidgetLocationChangeEvent(url: string, callbacks: WidgetPostMessageCallbackProps) {
-  callbacks.onMessage?.(url)
-
   try {
+    dispatchLocationChangeCatchAll(url, callbacks)
     const payload = buildPayloadFromUrl(url)
-    switch (payload.type) {
-      case Type.Load:
-        callbacks.onLoad?.(payload)
-        break
-
-      case Type.Ping:
-        callbacks.onPing?.(payload)
-        break
-
-      case Type.FocusTrap:
-        callbacks.onFocusTrap?.(payload)
-        break
-
-      case Type.AccountCreated:
-        callbacks.onAccountCreated?.(payload)
-        break
-
-      default:
-        throw new PostMessageUnknownTypeError(payload.type)
-    }
+    dispatchWidgetInternalMessage(payload, callbacks)
   } catch (error) {
     dispatchError(url, error, callbacks)
+  }
+}
+
+function dispatchLocationChangeCatchAll(url: string, callbacks: WidgetPostMessageCallbackProps) {
+  callbacks.onMessage?.(url)
+}
+
+function dispatchWidgetInternalMessage(payload: Payload, callbacks: WidgetPostMessageCallbackProps) {
+  switch (payload.type) {
+    case Type.Load:
+      callbacks.onLoad?.(payload)
+      break
+
+    case Type.Ping:
+      callbacks.onPing?.(payload)
+      break
+
+    case Type.FocusTrap:
+      callbacks.onFocusTrap?.(payload)
+      break
+
+    case Type.AccountCreated:
+      callbacks.onAccountCreated?.(payload)
+      break
+
+    default:
+      throw new PostMessageUnknownTypeError(payload.type)
   }
 }
 
@@ -610,88 +617,91 @@ export function dispatchWidgetLocationChangeEvent(url: string, callbacks: Widget
  * @throws {unknown}
  */
 export function dispatchConnectLocationChangeEvent(url: string, callbacks: ConnectPostMessageCallbackProps) {
-  callbacks.onMessage?.(url)
-
   try {
+    dispatchLocationChangeCatchAll(url, callbacks)
     const payload = buildPayloadFromUrl(url)
-    switch (payload.type) {
-      case Type.Load:
-        callbacks.onLoad?.(payload)
-        break
-
-      case Type.Ping:
-        callbacks.onPing?.(payload)
-        break
-
-      case Type.FocusTrap:
-        callbacks.onFocusTrap?.(payload)
-        break
-
-      case Type.AccountCreated:
-        callbacks.onAccountCreated?.(payload)
-        break
-
-      case Type.ConnectLoaded:
-        callbacks.onLoaded?.(payload)
-        break
-
-      case Type.ConnectEnterCredentials:
-        callbacks.onEnterCredentials?.(payload)
-        break
-
-      case Type.ConnectInstitutionSearch:
-        callbacks.onInstitutionSearch?.(payload)
-        break
-
-      case Type.ConnectSelectedInstitution:
-        callbacks.onSelectedInstitution?.(payload)
-        break
-
-      case Type.ConnectMemberConnected:
-        callbacks.onMemberConnected?.(payload)
-        break
-
-      case Type.ConnectConnectedPrimaryAction:
-        callbacks.onConnectedPrimaryAction?.(payload)
-        break
-
-      case Type.ConnectMemberDeleted:
-        callbacks.onMemberDeleted?.(payload)
-        break
-
-      case Type.ConnectCreateMemberError:
-        callbacks.onCreateMemberError?.(payload)
-        break
-
-      case Type.ConnectMemberStatusUpdate:
-        callbacks.onMemberStatusUpdate?.(payload)
-        break
-
-      case Type.ConnectOAuthError:
-        callbacks.onOAuthError?.(payload)
-        break
-
-      case Type.ConnectOAuthRequested:
-        callbacks.onOAuthRequested?.(payload)
-        break
-
-      case Type.ConnectStepChange:
-        callbacks.onStepChange?.(payload)
-        break
-
-      case Type.ConnectSubmitMFA:
-        callbacks.onSubmitMFA?.(payload)
-        break
-
-      case Type.ConnectUpdateCredentials:
-        callbacks.onUpdateCredentials?.(payload)
-        break
-
-      default:
-        throw new PostMessageUnknownTypeError(payload.type)
-    }
+    dispatchConnectInternalMessage(payload, callbacks)
   } catch (error) {
     dispatchError(url, error, callbacks)
+  }
+}
+
+function dispatchConnectInternalMessage(payload: Payload, callbacks: ConnectPostMessageCallbackProps) {
+  switch (payload.type) {
+    case Type.Load:
+      callbacks.onLoad?.(payload)
+      break
+
+    case Type.Ping:
+      callbacks.onPing?.(payload)
+      break
+
+    case Type.FocusTrap:
+      callbacks.onFocusTrap?.(payload)
+      break
+
+    case Type.AccountCreated:
+      callbacks.onAccountCreated?.(payload)
+      break
+
+    case Type.ConnectLoaded:
+      callbacks.onLoaded?.(payload)
+      break
+
+    case Type.ConnectEnterCredentials:
+      callbacks.onEnterCredentials?.(payload)
+      break
+
+    case Type.ConnectInstitutionSearch:
+      callbacks.onInstitutionSearch?.(payload)
+      break
+
+    case Type.ConnectSelectedInstitution:
+      callbacks.onSelectedInstitution?.(payload)
+      break
+
+    case Type.ConnectMemberConnected:
+      callbacks.onMemberConnected?.(payload)
+      break
+
+    case Type.ConnectConnectedPrimaryAction:
+      callbacks.onConnectedPrimaryAction?.(payload)
+      break
+
+    case Type.ConnectMemberDeleted:
+      callbacks.onMemberDeleted?.(payload)
+      break
+
+    case Type.ConnectCreateMemberError:
+      callbacks.onCreateMemberError?.(payload)
+      break
+
+    case Type.ConnectMemberStatusUpdate:
+      callbacks.onMemberStatusUpdate?.(payload)
+      break
+
+    case Type.ConnectOAuthError:
+      callbacks.onOAuthError?.(payload)
+      break
+
+    case Type.ConnectOAuthRequested:
+      callbacks.onOAuthRequested?.(payload)
+      break
+
+    case Type.ConnectStepChange:
+      callbacks.onStepChange?.(payload)
+      break
+
+    case Type.ConnectSubmitMFA:
+      callbacks.onSubmitMFA?.(payload)
+      break
+
+    case Type.ConnectUpdateCredentials:
+      callbacks.onUpdateCredentials?.(payload)
+      break
+
+    default:
+      throw new PostMessageUnknownTypeError(payload.type)
   }
 }
 
@@ -704,35 +714,38 @@ export function dispatchConnectLocationChangeEvent(url: string, callbacks: Conne
  * @throws {unknown}
  */
 export function dispatchPulseLocationChangeEvent(url: string, callbacks: PulsePostMessageCallbackProps) {
-  callbacks.onMessage?.(url)
-
   try {
+    dispatchLocationChangeCatchAll(url, callbacks)
     const payload = buildPayloadFromUrl(url)
-    switch (payload.type) {
-      case Type.Load:
-        callbacks.onLoad?.(payload)
-        break
-
-      case Type.Ping:
-        callbacks.onPing?.(payload)
-        break
-
-      case Type.FocusTrap:
-        callbacks.onFocusTrap?.(payload)
-        break
-
-      case Type.AccountCreated:
-        callbacks.onAccountCreated?.(payload)
-        break
-
-      case Type.PulseOverdraftWarningCtaTransferFunds:
-        callbacks.onOverdraftWarningCtaTransferFunds?.(payload)
-        break
-
-      default:
-        throw new PostMessageUnknownTypeError(payload.type)
-    }
+    dispatchPulseInternalMessage(payload, callbacks)
   } catch (error) {
     dispatchError(url, error, callbacks)
+  }
+}
+
+function dispatchPulseInternalMessage(payload: Payload, callbacks: PulsePostMessageCallbackProps) {
+  switch (payload.type) {
+    case Type.Load:
+      callbacks.onLoad?.(payload)
+      break
+
+    case Type.Ping:
+      callbacks.onPing?.(payload)
+      break
+
+    case Type.FocusTrap:
+      callbacks.onFocusTrap?.(payload)
+      break
+
+    case Type.AccountCreated:
+      callbacks.onAccountCreated?.(payload)
+      break
+
+    case Type.PulseOverdraftWarningCtaTransferFunds:
+      callbacks.onOverdraftWarningCtaTransferFunds?.(payload)
+      break
+
+    default:
+      throw new PostMessageUnknownTypeError(payload.type)
   }
 }


### PR DESCRIPTION
Doing this so we can introduce a new "dispatchXPostMessageEvent" function that will rely on the same underlying internal message dispatching logic but use different parsing/validation logic.