### PR TITLE
Formatting Typescript with prettier

### DIFF
--- a/.github/workflows/build-typescript-package.yml
+++ b/.github/workflows/build-typescript-package.yml
@@ -21,10 +21,13 @@ jobs:
     - run: npm install
       working-directory: packages/typescript
 
-    - run: npm run build
+    - run: npm run format -- --check
       working-directory: packages/typescript
 
     - run: npm run lint
+      working-directory: packages/typescript
+
+    - run: npm run build
       working-directory: packages/typescript
 
     - run: npm run test

--- a/packages/typescript/package-lock.json
+++ b/packages/typescript/package-lock.json
@@ -15,6 +15,7 @@
         "@typescript-eslint/parser": "^5.13.0",
         "eslint": "^8.10.0",
         "jest": "^27.5.1",
+        "prettier": "^2.6.0",
         "ts-jest": "^27.1.3",
         "typescript": "^4.6.2"
       }
@@ -4204,6 +4205,21 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prettier": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.0.tgz",
+      "integrity": "sha512-m2FgJibYrBGGgQXNzfd0PuDGShJgRavjUoRCw1mZERIWVSXF0iLzLm+aOqTAbLnC3n6JzUhAA8uZnFVghHJ86A==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
@@ -8311,6 +8327,12 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "prettier": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.0.tgz",
+      "integrity": "sha512-m2FgJibYrBGGgQXNzfd0PuDGShJgRavjUoRCw1mZERIWVSXF0iLzLm+aOqTAbLnC3n6JzUhAA8uZnFVghHJ86A==",
       "dev": true
     },
     "pretty-format": {

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -5,6 +5,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "scripts": {
+    "format": "prettier -w src test '!**/generated.*'",
     "build": "[ -d dist ] && rm -r dist; tsc --outDir dist --declaration",
     "test": "jest --verbose --coverage",
     "lint": "eslint src test",
@@ -21,6 +22,7 @@
     "@typescript-eslint/parser": "^5.13.0",
     "eslint": "^8.10.0",
     "jest": "^27.5.1",
+    "prettier": "^2.6.0",
     "ts-jest": "^27.1.3",
     "typescript": "^4.6.2"
   },
@@ -71,5 +73,11 @@
         }
       ]
     }
+  },
+  "prettier": {
+    "printWidth": 100,
+    "semi": false,
+    "trailingComma": "all",
+    "singleQuote": false
   }
 }

--- a/packages/typescript/src/lib.ts
+++ b/packages/typescript/src/lib.ts
@@ -45,7 +45,12 @@ export type NestedValue = Record<string, Value>
 export type TypeDef = string | Array<string> | Record<string, string>
 export type Metadata = Record<string, Value | NestedValue>
 
-export function assertMessageProp(container: Metadata, postMessageType: string, field: string, expectedType: TypeDef) {
+export function assertMessageProp(
+  container: Metadata,
+  postMessageType: string,
+  field: string,
+  expectedType: TypeDef,
+) {
   const value = container[field]
 
   const valueIsDefined = typeof value !== "undefined"

--- a/packages/typescript/test/post_message_dispatch_test.ts
+++ b/packages/typescript/test/post_message_dispatch_test.ts
@@ -45,7 +45,7 @@ const connectionStatus = 6
 const connectMemberStatusUpdateUrl = genPostMessageUrl("mx://connect/memberStatusUpdate", {
   ...session,
   member_guid: memberGuid,
-  connection_status: connectionStatus
+  connection_status: connectionStatus,
 })
 
 const institutionCode = "INST"
@@ -56,14 +56,17 @@ const connectUpdateCredentialsUrl = genPostMessageUrl("mx://connect/updateCreden
   institution: {
     code: institutionCode,
     guid: institutionGuid,
-  }
+  },
 })
 
 const amount = 42
-const pulseOverdraftWarningCtaTransferFundsUrl = genPostMessageUrl("mx://pulse/overdraftWarning/cta/transferFunds", {
-  account_guid: accountGuid,
-  amount: amount,
-})
+const pulseOverdraftWarningCtaTransferFundsUrl = genPostMessageUrl(
+  "mx://pulse/overdraftWarning/cta/transferFunds",
+  {
+    account_guid: accountGuid,
+    amount: amount,
+  },
+)
 
 const invalidMessageUrl = genPostMessageUrl("mx://bad/memberDeleted", {
   ...session,
@@ -74,7 +77,9 @@ const account = {
 }
 const accountCreatedUrl = genPostMessageUrl("ms://account/created", account)
 
-const testSharedCallbacks = (dispatch: (url: string, callbacks: WidgetPostMessageCallbackProps) => void) => {
+const testSharedCallbacks = (
+  dispatch: (url: string, callbacks: WidgetPostMessageCallbackProps) => void,
+) => {
   describe("onMessage", () => {
     test("callback is called with valid post message", () => {
       expect.assertions(1)
@@ -82,7 +87,7 @@ const testSharedCallbacks = (dispatch: (url: string, callbacks: WidgetPostMessag
       dispatch(connectMemberDeletedUrl, {
         onMessage: (url) => {
           expect(url).toBe(connectMemberDeletedUrl)
-        }
+        },
       })
     })
 
@@ -92,7 +97,7 @@ const testSharedCallbacks = (dispatch: (url: string, callbacks: WidgetPostMessag
       dispatch(invalidMessageUrl, {
         onMessage: (url) => {
           expect(url).toBe(invalidMessageUrl)
-        }
+        },
       })
     })
   })
@@ -105,7 +110,7 @@ const testSharedCallbacks = (dispatch: (url: string, callbacks: WidgetPostMessag
         onInvalidMessageError: (url, error) => {
           expect(url).toBe(invalidMessageUrl)
           expect(error.message).toContain("Unknown post message: mx/bad/memberDeleted")
-        }
+        },
       })
     })
 
@@ -115,8 +120,10 @@ const testSharedCallbacks = (dispatch: (url: string, callbacks: WidgetPostMessag
       dispatch(connectMemberDeletedUrlInvalidField, {
         onInvalidMessageError: (url, error) => {
           expect(url).toBe(connectMemberDeletedUrlInvalidField)
-          expect(error.message).toContain("Unable to decode 'member_guid' from 'mx/connect/memberDeleted")
-        }
+          expect(error.message).toContain(
+            "Unable to decode 'member_guid' from 'mx/connect/memberDeleted",
+          )
+        },
       })
     })
 
@@ -126,8 +133,10 @@ const testSharedCallbacks = (dispatch: (url: string, callbacks: WidgetPostMessag
       dispatch(connectMemberDeletedUrlMissingField, {
         onInvalidMessageError: (url, error) => {
           expect(url).toBe(connectMemberDeletedUrlMissingField)
-          expect(error.message).toContain("Unable to decode 'member_guid' from 'mx/connect/memberDeleted")
-        }
+          expect(error.message).toContain(
+            "Unable to decode 'member_guid' from 'mx/connect/memberDeleted",
+          )
+        },
       })
     })
   })
@@ -138,7 +147,7 @@ const testSharedCallbacks = (dispatch: (url: string, callbacks: WidgetPostMessag
         dispatch(loadUrl, {
           onLoad: () => {
             throw new Error("bad to the bone")
-          }
+          },
         })
       }).toThrow()
     })
@@ -151,7 +160,7 @@ const testSharedCallbacks = (dispatch: (url: string, callbacks: WidgetPostMessag
       dispatch(loadUrl, {
         onLoad: (payload) => {
           expect(payload).toBeDefined()
-        }
+        },
       })
     })
 
@@ -161,7 +170,7 @@ const testSharedCallbacks = (dispatch: (url: string, callbacks: WidgetPostMessag
       dispatch(pingUrl, {
         onPing: (payload) => {
           expect(payload.user_guid).toBe(userGuid)
-        }
+        },
       })
     })
 
@@ -171,7 +180,7 @@ const testSharedCallbacks = (dispatch: (url: string, callbacks: WidgetPostMessag
       dispatch(focusTrapUrl, {
         onFocusTrap: (payload) => {
           expect(payload.user_guid).toBe(userGuid)
-        }
+        },
       })
     })
   })
@@ -183,7 +192,7 @@ const testSharedCallbacks = (dispatch: (url: string, callbacks: WidgetPostMessag
       dispatch(accountCreatedUrl, {
         onAccountCreated: (payload) => {
           expect(payload.guid).toBe(accountGuid)
-        }
+        },
       })
     })
   })
@@ -205,7 +214,7 @@ describe("Post Message Dispatch", () => {
           onOverdraftWarningCtaTransferFunds: (payload) => {
             expect(payload.account_guid).toBe(accountGuid)
             expect(payload.amount).toBe(amount)
-          }
+          },
         })
       })
     })
@@ -223,7 +232,7 @@ describe("Post Message Dispatch", () => {
             expect(payload.member_guid).toBe(memberGuid)
             expect(payload.user_guid).toBe(userGuid)
             expect(payload.session_guid).toBe(sessionGuid)
-          }
+          },
         })
       })
 
@@ -236,7 +245,7 @@ describe("Post Message Dispatch", () => {
           },
           onMemberDeleted: (payload) => {
             expect(payload.member_guid).toBe(memberGuid)
-          }
+          },
         })
       })
 
@@ -246,7 +255,7 @@ describe("Post Message Dispatch", () => {
         dispatchConnectLocationChangeEvent(connectLoadedUrl, {
           onLoaded: (payload) => {
             expect(payload.initial_step).toBe(initialStep)
-          }
+          },
         })
       })
 
@@ -256,7 +265,7 @@ describe("Post Message Dispatch", () => {
         dispatchConnectLocationChangeEvent(connectMemberStatusUpdateUrl, {
           onMemberStatusUpdate: (payload) => {
             expect(payload.connection_status).toBe(connectionStatus)
-          }
+          },
         })
       })
 
@@ -267,7 +276,7 @@ describe("Post Message Dispatch", () => {
           onUpdateCredentials: (payload) => {
             expect(payload.institution.code).toBe(institutionCode)
             expect(payload.institution.guid).toBe(institutionGuid)
-          }
+          },
         })
       })
     })


### PR DESCRIPTION
Adds an `npm run format` command that formats all files that need to be formatted, also updates CI to check that formatting was done.