### PR TITLE
Adding warning to mx/connect/stepChange

### DIFF
--- a/lib/post_message_definition.yml
+++ b/lib/post_message_definition.yml
@@ -91,6 +91,9 @@ post_messages:
           url: string
           member_guid: string
       stepChange:
+        warning: |
+          This message is intended for analytics tracking purposes and not
+          controlling or altering user experience.
         payload:
           <<: *user_session_properties
           previous: string

--- a/lib/post_message_definition.yml
+++ b/lib/post_message_definition.yml
@@ -93,7 +93,8 @@ post_messages:
       stepChange:
         warning: |
           This message is intended for analytics tracking purposes and not
-          controlling or altering user experience.
+          controlling or altering user experience. The contents of this
+          message's payload is subject to change.
         payload:
           <<: *user_session_properties
           previous: string

--- a/packages/typescript/docs/generated.md
+++ b/packages/typescript/docs/generated.md
@@ -351,6 +351,9 @@ import { ConnectWidget } from "@mxenabled/react-native-widget-sdk"
 ---
 ### Step change (`mx/connect/stepChange`)
 
+**Warning**: This message is intended for analytics tracking purposes and not
+controlling or altering user experience.
+
 - Widget callback prop name: `onStepChange`
 - Payload fields:
     - `user_guid` (`string`)

--- a/packages/typescript/docs/generated.md
+++ b/packages/typescript/docs/generated.md
@@ -352,7 +352,8 @@ import { ConnectWidget } from "@mxenabled/react-native-widget-sdk"
 ### Step change (`mx/connect/stepChange`)
 
 **Warning**: This message is intended for analytics tracking purposes and not
-controlling or altering user experience.
+controlling or altering user experience. The contents of this
+message's payload is subject to change.
 
 - Widget callback prop name: `onStepChange`
 - Payload fields:


### PR DESCRIPTION
As per our conversation from last week, I'm adding a warning to the documentation for `mx/connect/stepChange`. It mentions that it for analytics purposes and not controlling user experience.