### PR TITLE
WIP: Adding member_guid property to connect/oauthError post message

### DIFF
--- a/lib/post_message_definition.yml
+++ b/lib/post_message_definition.yml
@@ -74,6 +74,7 @@ post_messages:
       oauthError:
         payload:
           <<: *user_session_properties
+          member_guid: string
       oauthRequested:
         warning: |
           By passing your own method to this prop, you are overriding the

--- a/packages/typescript/docs/react-native-sdk-generated.md
+++ b/packages/typescript/docs/react-native-sdk-generated.md
@@ -288,6 +288,7 @@ import { ConnectWidget } from "@mxenabled/react-native-widget-sdk"
 - Payload fields:
     - `user_guid` (`string`)
     - `session_guid` (`string`)
+    - `member_guid` (`string`)
 
 <details>
 <summary>Click here to view a sample usage of <code>onOAuthError</code>.</summary>
@@ -301,6 +302,7 @@ import { ConnectWidget } from "@mxenabled/react-native-widget-sdk"
   onOAuthError={(payload) => {
     console.log(`User guid: ${payload.user_guid}`)
     console.log(`Session guid: ${payload.session_guid}`)
+    console.log(`Member guid: ${payload.member_guid}`)
   }
 />
 ```

--- a/packages/typescript/docs/web-sdk-generated.md
+++ b/packages/typescript/docs/web-sdk-generated.md
@@ -270,6 +270,7 @@ const widget = widgetSdk.ConnectWidget({
 - Payload fields:
     - `user_guid` (`string`)
     - `session_guid` (`string`)
+    - `member_guid` (`string`)
 
 <details>
 <summary>Click here to view a sample usage of <code>onOAuthError</code>.</summary>
@@ -281,6 +282,7 @@ const widget = widgetSdk.ConnectWidget({
   onOAuthError: (payload) => {
     console.log(`User guid: ${payload.user_guid}`)
     console.log(`Session guid: ${payload.session_guid}`)
+    console.log(`Member guid: ${payload.member_guid}`)
   }
 })
 ```

--- a/packages/typescript/src/generated.ts
+++ b/packages/typescript/src/generated.ts
@@ -163,6 +163,7 @@ export type ConnectOAuthErrorPayload = {
   type: Type.ConnectOAuthError,
   user_guid: string,
   session_guid: string,
+  member_guid: string,
 }
 
 export type ConnectOAuthRequestedPayload = {
@@ -390,11 +391,13 @@ function buildPayload(type: Type, metadata: Metadata): Payload {
     case Type.ConnectOAuthError:
       assertMessageProp(metadata, "mx/connect/oauthError", "user_guid", "string")
       assertMessageProp(metadata, "mx/connect/oauthError", "session_guid", "string")
+      assertMessageProp(metadata, "mx/connect/oauthError", "member_guid", "string")
 
       return {
         type,
         user_guid: metadata.user_guid as string,
         session_guid: metadata.session_guid as string,
+        member_guid: metadata.member_guid as string,
       }
 
     case Type.ConnectOAuthRequested:


### PR DESCRIPTION
Will need to add support of optional fields, this PR is still WIP.

Example of the post message with the member_guid field:

```
mxwidgetsdkdemo://connect/oauthError?metadata=%7B%22session_guid%22%3A%22ANS-7c82b71f-16b4-4f92-8570-9f140af45cef%22%2C%22user_guid%22%3A%22USR-081ff65e-3087-4cc2-a2c4-365354e1e6cb%22%2C%22member_guid%22%3A%22MBR-67bdf94f-8b08-42eb-a85e-709df44af4ed%22%2C%22error_reason%22%3A%22SERVER_ERROR%22%7D
```