### PR TITLE
Storing payload field info in class that will allow for field properties

### DIFF
--- a/lib/post_message_definition.yml
+++ b/lib/post_message_definition.yml
@@ -26,19 +26,21 @@ post_messages:
         payload:
           <<: *user_session_properties
           initial_step:
-            - search
-            - selectMember
-            - enterCreds
-            - mfa
-            - connected
-            - loginError
-            - disclosure
+            type:
+              - search
+              - selectMember
+              - enterCreds
+              - mfa
+              - connected
+              - loginError
+              - disclosure
       enterCredentials:
         payload:
           <<: *user_session_properties
           institution:
-            code: string
-            guid: string
+            type:
+              code: string
+              guid: string
       institutionSearch:
         payload:
           <<: *user_session_properties
@@ -74,6 +76,9 @@ post_messages:
       oauthError:
         payload:
           <<: *user_session_properties
+          # member_guid:
+          #   type: string
+          #   required: false
       oauthRequested:
         warning: |
           By passing your own method to this prop, you are overriding the
@@ -108,8 +113,9 @@ post_messages:
           <<: *user_session_properties
           member_guid: string
           institution:
-            code: string
-            guid: string
+            type:
+              code: string
+              guid: string
     pulse:
       overdraftWarning/cta/transferFunds:
         payload:

--- a/lib/template/typescript_documentation.rb
+++ b/lib/template/typescript_documentation.rb
@@ -27,20 +27,20 @@ class Template::TypescriptDocumentation < Template::TypescriptSource
     |- Widget callback prop name: `<%= callback_function_name(post_message) %>`
     |<%- unless post_message.payload.empty? -%>
     |- Payload fields:
-    |    <%- post_message.payload.each do |property, rhs| -%>
-    |    <%- if rhs.is_a?(Array) -%>
-    |    - `<%= property %>` (`<%= payload_property_type("string") %>`)
+    |    <%- post_message.payload.each do |field| -%>
+    |    <%- if field.type.is_a?(Array) -%>
+    |    - `<%= field.name %>` (`<%= payload_property_type("string") %>`)
     |        - One of:
-    |            <%- rhs.each do |option| -%>
+    |            <%- field.type.each do |option| -%>
     |            - `"<%= option %>"`
     |            <%- end -%>
-    |    <%- elsif rhs.is_a?(Hash) -%>
-    |    - `<%= property %>` (`<%= payload_property_type("object") %>`)
-    |        <%- rhs.each do |property, deep_rhs| -%>
+    |    <%- elsif field.type.is_a?(Hash) -%>
+    |    - `<%= field.name %>` (`<%= payload_property_type("object") %>`)
+    |        <%- field.type.each do |property, deep_rhs| -%>
     |        - `<%= property %>` (`<%= payload_property_type(deep_rhs) %>`)
     |        <%- end -%>
     |    <%- else -%>
-    |    - `<%= property %>` (`<%= payload_property_type(rhs) %>`)
+    |    - `<%= field.name %>` (`<%= payload_property_type(field.type) %>`)
     |    <%- end -%>
     |    <%- end -%>
     |<%- end -%>

--- a/lib/template/typescript_react_native_documentation.rb
+++ b/lib/template/typescript_react_native_documentation.rb
@@ -11,8 +11,8 @@ class Template::TypescriptReactNativeDocumentation < Template::TypescriptDocumen
     |  url="<%= widget_sample_url(widget) %>"
     |
     |  <%= callback_function_name(post_message) %>={(payload) => {
-    |    <%- post_message.payload.each do |property, rhs| -%>
-    |    console.log(`<%= property.titleize %>: ${payload.<%= property %>}`)
+    |    <%- post_message.payload.each do |field| -%>
+    |    console.log(`<%= field.name.titleize %>: ${payload.<%= field.name %>}`)
     |    <%- end -%>
     |  }
     |/>

--- a/lib/template/typescript_source.rb
+++ b/lib/template/typescript_source.rb
@@ -27,8 +27,8 @@ class Template::TypescriptSource < Template::Base
     |<% post_message_definitions.each do |post_message| %>
     |export type <%= payload_type_name(post_message) %> = {
     |  type: <%= qualified_enum_key(post_message) %>,
-    |  <%- post_message.payload.each do |property, rhs| -%>
-    |  <%= property %>: <%= payload_property_type(rhs) %>,
+    |  <%- post_message.payload.each do |field| -%>
+    |  <%= field.name %>: <%= payload_property_type(field.type) %>,
     |  <%- end -%>
     |}
     |<%- end -%>
@@ -57,14 +57,14 @@ class Template::TypescriptSource < Template::Base
     |  switch (type) {
     |    <%- post_message_definitions.each do |post_message| -%>
     |    case <%= qualified_enum_key(post_message) %>:
-    |      <%- post_message.payload.each do |property, rhs| -%>
-    |      assertMessageProp(metadata, "<%= post_message %>", "<%= property %>", <%= payload_property_type(rhs, :code) %>)
+    |      <%- post_message.payload.each do |field| -%>
+    |      assertMessageProp(metadata, "<%= post_message %>", "<%= field.name %>", <%= payload_property_type(field.type, :code) %>)
     |      <%- end -%>
     |
     |      return {
     |        type,
-    |        <%- post_message.payload.each do |property, rhs| -%>
-    |        <%= property %>: metadata.<%= property %> as <%= payload_property_type(rhs) %>,
+    |        <%- post_message.payload.each do |field| -%>
+    |        <%= field.name %>: metadata.<%= field.name %> as <%= payload_property_type(field.type) %>,
     |        <%- end -%>
     |      }
     |

--- a/lib/template/typescript_web_documentation.rb
+++ b/lib/template/typescript_web_documentation.rb
@@ -9,8 +9,8 @@ class Template::TypescriptWebDocumentation < Template::TypescriptDocumentation
     |  url: "<%= widget_sample_url(widget) %>",
     |
     |  <%= callback_function_name(post_message) %>: (payload) => {
-    |    <%- post_message.payload.each do |property, rhs| -%>
-    |    console.log(`<%= property.titleize %>: ${payload.<%= property %>}`)
+    |    <%- post_message.payload.each do |field| -%>
+    |    console.log(`<%= field.name.titleize %>: ${payload.<%= field.name %>}`)
     |    <%- end -%>
     |  }
     |})


### PR DESCRIPTION
Updating how payload message field information is stored. Fields were stored in a simple hash where the key was the field name and the value was its type, but since we'll need additional info as part of the field information (eg, if it's required or not), I'm updating it to store field info in a new class. This change does not alter the generated output of the generators, it just modifies how field info is store internally.