### PR TITLE
Optional fields + adding oauthError member_guid field

### DIFF
--- a/lib/post_message_definition.rb
+++ b/lib/post_message_definition.rb
@@ -16,6 +16,11 @@ class PostMessageDefinition
       @type = type
       @properties = properties
     end
+
+    # @return [Boolean]
+    def optional?
+      @properties["optional"] == true
+    end
   end
 
   # @param [Hash] definitions

--- a/lib/post_message_definition.yml
+++ b/lib/post_message_definition.yml
@@ -76,6 +76,9 @@ post_messages:
       oauthError:
         payload:
           <<: *user_session_properties
+          member_guid:
+            type: string
+            optional: true
       oauthRequested:
         warning: |
           By passing your own method to this prop, you are overriding the

--- a/lib/template/typescript_documentation.rb
+++ b/lib/template/typescript_documentation.rb
@@ -29,18 +29,18 @@ class Template::TypescriptDocumentation < Template::TypescriptSource
     |- Payload fields:
     |    <%- post_message.payload.each do |field| -%>
     |    <%- if field.type.is_a?(Array) -%>
-    |    - `<%= field.name %>` (`<%= payload_property_type("string") %>`)
+    |    - <%= payload_field_heading(field) %> (`<%= payload_property_type("string") %>`)
     |        - One of:
     |            <%- field.type.each do |option| -%>
     |            - `"<%= option %>"`
     |            <%- end -%>
     |    <%- elsif field.type.is_a?(Hash) -%>
-    |    - `<%= field.name %>` (`<%= payload_property_type("object") %>`)
+    |    - <%= payload_field_heading(field) %> (`<%= payload_property_type("object") %>`)
     |        <%- field.type.each do |property, deep_rhs| -%>
     |        - `<%= property %>` (`<%= payload_property_type(deep_rhs) %>`)
     |        <%- end -%>
     |    <%- else -%>
-    |    - `<%= field.name %>` (`<%= payload_property_type(field.type) %>`)
+    |    - <%= payload_field_heading(field) %> (`<%= payload_property_type(field.type) %>`)
     |    <%- end -%>
     |    <%- end -%>
     |<%- end -%>
@@ -50,6 +50,14 @@ class Template::TypescriptDocumentation < Template::TypescriptSource
     |<%- end -%>
     |<%- end -%>
   ITEM_FOOTER
+
+  def payload_field_heading(field)
+    if field.optional?
+      "`#{field.name}` (optional)"
+    else
+      "`#{field.name}`"
+    end
+  end
 
   # @example
   #

--- a/lib/template/typescript_documentation.rb
+++ b/lib/template/typescript_documentation.rb
@@ -51,6 +51,8 @@ class Template::TypescriptDocumentation < Template::TypescriptSource
     |<%- end -%>
   ITEM_FOOTER
 
+  # @param [PostMessageDefinition::PayloadField] field
+  # @return [String]
   def payload_field_heading(field)
     if field.optional?
       "`#{field.name}` (optional)"

--- a/lib/template/typescript_source.rb
+++ b/lib/template/typescript_source.rb
@@ -28,7 +28,11 @@ class Template::TypescriptSource < Template::Base
     |export type <%= payload_type_name(post_message) %> = {
     |  type: <%= qualified_enum_key(post_message) %>,
     |  <%- post_message.payload.each do |field| -%>
+    |  <%- if field.optional? -%>
+    |  <%= field.name %>?: <%= payload_property_type(field.type) %>,
+    |  <%- else -%>
     |  <%= field.name %>: <%= payload_property_type(field.type) %>,
+    |  <%- end -%>
     |  <%- end -%>
     |}
     |<%- end -%>
@@ -58,13 +62,23 @@ class Template::TypescriptSource < Template::Base
     |    <%- post_message_definitions.each do |post_message| -%>
     |    case <%= qualified_enum_key(post_message) %>:
     |      <%- post_message.payload.each do |field| -%>
+    |      <%- if field.optional? -%>
+    |      assertMessageProp(metadata, "<%= post_message %>", "<%= field.name %>", <%= payload_property_type(field.type, :code) %>, {
+    |        optional: true,
+    |      })
+    |      <%- else -%>
     |      assertMessageProp(metadata, "<%= post_message %>", "<%= field.name %>", <%= payload_property_type(field.type, :code) %>)
+    |      <%- end -%>
     |      <%- end -%>
     |
     |      return {
     |        type,
     |        <%- post_message.payload.each do |field| -%>
+    |        <%- if field.optional? -%>
+    |        <%= field.name %>: metadata.<%= field.name %> as <%= payload_property_type(field.type) %> | undefined,
+    |        <%- else -%>
     |        <%= field.name %>: metadata.<%= field.name %> as <%= payload_property_type(field.type) %>,
+    |        <%- end -%>
     |        <%- end -%>
     |      }
     |

--- a/packages/typescript/docs/react-native-sdk-generated.md
+++ b/packages/typescript/docs/react-native-sdk-generated.md
@@ -288,6 +288,7 @@ import { ConnectWidget } from "@mxenabled/react-native-widget-sdk"
 - Payload fields:
     - `user_guid` (`string`)
     - `session_guid` (`string`)
+    - `member_guid` (optional) (`string`)
 
 <details>
 <summary>Click here to view a sample usage of <code>onOAuthError</code>.</summary>
@@ -301,6 +302,7 @@ import { ConnectWidget } from "@mxenabled/react-native-widget-sdk"
   onOAuthError={(payload) => {
     console.log(`User guid: ${payload.user_guid}`)
     console.log(`Session guid: ${payload.session_guid}`)
+    console.log(`Member guid: ${payload.member_guid}`)
   }
 />
 ```

--- a/packages/typescript/docs/web-sdk-generated.md
+++ b/packages/typescript/docs/web-sdk-generated.md
@@ -270,6 +270,7 @@ const widget = widgetSdk.ConnectWidget({
 - Payload fields:
     - `user_guid` (`string`)
     - `session_guid` (`string`)
+    - `member_guid` (optional) (`string`)
 
 <details>
 <summary>Click here to view a sample usage of <code>onOAuthError</code>.</summary>
@@ -281,6 +282,7 @@ const widget = widgetSdk.ConnectWidget({
   onOAuthError: (payload) => {
     console.log(`User guid: ${payload.user_guid}`)
     console.log(`Session guid: ${payload.session_guid}`)
+    console.log(`Member guid: ${payload.member_guid}`)
   }
 })
 ```

--- a/packages/typescript/src/generated.ts
+++ b/packages/typescript/src/generated.ts
@@ -163,6 +163,7 @@ export type ConnectOAuthErrorPayload = {
   type: Type.ConnectOAuthError,
   user_guid: string,
   session_guid: string,
+  member_guid?: string,
 }
 
 export type ConnectOAuthRequestedPayload = {
@@ -390,11 +391,15 @@ function buildPayload(type: Type, metadata: Metadata): Payload {
     case Type.ConnectOAuthError:
       assertMessageProp(metadata, "mx/connect/oauthError", "user_guid", "string")
       assertMessageProp(metadata, "mx/connect/oauthError", "session_guid", "string")
+      assertMessageProp(metadata, "mx/connect/oauthError", "member_guid", "string", {
+        optional: true,
+      })
 
       return {
         type,
         user_guid: metadata.user_guid as string,
         session_guid: metadata.session_guid as string,
+        member_guid: metadata.member_guid as string | undefined,
       }
 
     case Type.ConnectOAuthRequested:

--- a/packages/typescript/src/lib.ts
+++ b/packages/typescript/src/lib.ts
@@ -46,6 +46,10 @@ export type MessageEventData = {
   type?: string
 }
 
+type FieldProperties = {
+  optional?: boolean
+}
+
 export type Value = string | number
 export type NestedValue = Record<string, Value>
 export type TypeDef = string | Array<string> | Record<string, string>
@@ -56,6 +60,7 @@ export function assertMessageProp(
   postMessageType: string,
   field: string,
   expectedType: TypeDef,
+  properties: FieldProperties = {}
 ) {
   const value = container[field]
 
@@ -69,7 +74,9 @@ export function assertMessageProp(
   const typeIsArray = expectedType instanceof Array
   const typeIsObject = typeof expectedType === "object" && !Array.isArray(expectedType)
 
-  if (!valueIsDefined) {
+  if (!valueIsDefined && properties.optional) {
+    return
+  } else if (!valueIsDefined) {
     throw new PostMessageFieldDecodeError(postMessageType, field, expectedType, value)
   } else if (typeIsString && !valueIsString) {
     throw new PostMessageFieldDecodeError(postMessageType, field, expectedType, value)

--- a/packages/typescript/src/lib.ts
+++ b/packages/typescript/src/lib.ts
@@ -60,7 +60,7 @@ export function assertMessageProp(
   postMessageType: string,
   field: string,
   expectedType: TypeDef,
-  properties: FieldProperties = {}
+  properties: FieldProperties = {},
 ) {
   const value = container[field]
 

--- a/packages/typescript/test/post_message_dispatch_test.ts
+++ b/packages/typescript/test/post_message_dispatch_test.ts
@@ -71,6 +71,15 @@ const connectUpdateCredentialsUrl = genPostMessageUrl("mx://connect/updateCreden
   },
 })
 
+const connectOAuthErrorWithMemberGuidUrl = genPostMessageUrl("mx://connect/oauthError", {
+  ...session,
+  member_guid: memberGuid,
+})
+
+const connectOAuthErrorWithoutMemberGuidUrl = genPostMessageUrl("mx://connect/oauthError", {
+  ...session,
+})
+
 const amount = 42
 const pulseOverdraftWarningCtaTransferFundsUrl = genPostMessageUrl(
   "mx://pulse/overdraftWarning/cta/transferFunds",
@@ -293,6 +302,28 @@ describe("Post Message Dispatch", () => {
             expect(payload.institution.code).toBe(institutionCode)
             expect(payload.institution.guid).toBe(institutionGuid)
           },
+        })
+      })
+
+      describe("optional fields", () => {
+        test("optional field is included", () => {
+          expect.assertions(1)
+
+          dispatchConnectLocationChangeEvent(connectOAuthErrorWithMemberGuidUrl, {
+            onOAuthError: (payload) => {
+              expect(payload.member_guid).toBe(memberGuid)
+            },
+          })
+        })
+
+        test("optional field is excluded", () => {
+          expect.assertions(1)
+
+          dispatchConnectLocationChangeEvent(connectOAuthErrorWithoutMemberGuidUrl, {
+            onOAuthError: (payload) => {
+              expect(payload.member_guid).toBe(undefined)
+            },
+          })
         })
       })
     })


### PR DESCRIPTION
Adding support for optional fields and declares an optional `member_guid` field in the `mx/connect/oauthError` post message. Depends on https://github.com/mxenabled/widget-post-message-definitions/pull/13.