### PR TITLE
Post Message documented property

### DIFF
--- a/lib/post_message_definition.rb
+++ b/lib/post_message_definition.rb
@@ -57,4 +57,8 @@ class PostMessageDefinition
   def entity?
     group == :entity
   end
+
+  def documented?
+    properties.fetch("documented", true)
+  end
 end

--- a/lib/template/typescript_documentation.rb
+++ b/lib/template/typescript_documentation.rb
@@ -18,6 +18,7 @@ class Template::TypescriptDocumentation < Template::TypescriptSource
     |## <%= widget_name(widget) %> Post Messages
     |
     |<%- post_messages.each do |post_message| -%>
+    |<%- next unless post_message.documented? -%>
     |---
     |### <%= normalize_keywords(post_message.label.to_s.titleize) %> (`<%= post_message %>`)
     |


### PR DESCRIPTION
Adding `documented: false` to a post message will prevent it from being included in the generated documentation.

Example:

```yaml
post_messages:
  widget:
    connect:
      institutionSearch:
        documented: false
        payload:
          <<: *user_session_properties
          query: string
```