### PR TITLE
Standardizing build triggers

### DIFF
--- a/.github/workflows/build-ruby-generator.yml
+++ b/.github/workflows/build-ruby-generator.yml
@@ -1,6 +1,10 @@
 name: Build Ruby Generator
 
-on: pull_request
+on:
+  pull_request:
+  push:
+    branches:
+    - master
 
 jobs:
   Build:

--- a/.github/workflows/build-typescript-package.yml
+++ b/.github/workflows/build-typescript-package.yml
@@ -3,8 +3,11 @@ name: Build TypeScript Package
 on:
   pull_request:
     paths:
-      - packages/typescript/**
-      - .github/workflows/build-typescript-package.yml
+    - packages/typescript/**
+    - .github/workflows/build-typescript-package.yml
+  push:
+    branches:
+    - master
 
 jobs:
   Build:


### PR DESCRIPTION
Updating builds so that they trigger only after a pull request is created _and_ after every single push to the master branch. Cron schedules are unaffected by this change.