### PR TITLE
Pinning Psych version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,5 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 gem "mad_rubocop"
 gem "pry"
+gem "psych", "~> 3"
 gem "rubocop", "~> 1.25.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,6 +23,7 @@ GEM
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    psych (3.3.2)
     rack (2.2.3.1)
     rainbow (3.1.1)
     regexp_parser (2.5.0)
@@ -57,6 +58,7 @@ PLATFORMS
 DEPENDENCIES
   mad_rubocop
   pry
+  psych (~> 3)
   rubocop (~> 1.25.0)
 
 BUNDLED WITH


### PR DESCRIPTION
Psych is a core library of Ruby so it's not necessary to define it in the project's dependency list, but I'm adding it as a way to prevent version mismatch. This fixes an issue that Sam was running into.