### PR TITLE
Add oauthComplete post message definition.

### DIFF
--- a/lib/post_message_definition.yml
+++ b/lib/post_message_definition.yml
@@ -28,6 +28,11 @@ post_messages:
       focusTrap:
         payload:
           <<: *user_session_properties
+    client:
+      oauthComplete:
+        documented: false
+        payload:
+          url: string
     # This list was taken from this documentation:
     # https://docs.mx.com/api#connect_postmessage_events
     connect:


### PR DESCRIPTION
The SDK listens for this from a client so it can communicates success
and errors to the connect widget.