### PR TITLE
Generating Swift payload structs

### DIFF
--- a/lib/core_refinements/string_refinement.rb
+++ b/lib/core_refinements/string_refinement.rb
@@ -26,6 +26,17 @@ module StringRefinement
 
     # @example
     #
+    #   "hi_there".camel_case # => "hiThere"
+    #   "hi_thereMan".camel_case # => "hiThereMan"
+    #
+    # @return [String]
+    def camel_case
+      word = self.classify
+      word[0].downcase + word.split("").drop(1).join
+    end
+
+    # @example
+    #
     #   classify("hi_there") # => "HiThere"
     #   classify("hi_thereMan") # => "HiThereMan"
     #

--- a/lib/post_message_definition.rb
+++ b/lib/post_message_definition.rb
@@ -33,6 +33,7 @@ class PostMessageDefinition
     end
 
     # Returns the class type of the value representing the field's type.
+    #
     # @return [Symbol]
     def type_type
       type.class.to_s.downcase.to_sym

--- a/lib/post_message_definition.rb
+++ b/lib/post_message_definition.rb
@@ -21,6 +21,29 @@ class PostMessageDefinition
     def optional?
       @properties["optional"] == true
     end
+
+    # @return [Boolean]
+    def enum?
+      type_type == :array
+    end
+
+    # @return [Boolean]
+    def struct?
+      type_type == :hash
+    end
+
+    # Returns the class type of the value representing the field's type.
+    # @return [Symbol]
+    def type_type
+      type.class.to_s.downcase.to_sym
+    end
+
+    # @return [Array<PayloadField>]
+    def struct_fields
+      type.map do |(name, type)|
+        self.class.new(name, type)
+      end
+    end
   end
 
   # @param [Hash] definitions
@@ -75,6 +98,11 @@ class PostMessageDefinition
   end
 
   # @return [Boolean]
+  def client?
+    subgroup == :client
+  end
+
+  # @return [Boolean]
   def generic?
     subgroup == :generic
   end
@@ -82,6 +110,11 @@ class PostMessageDefinition
   # @return [Boolean]
   def entity?
     group == :entity
+  end
+
+  # @return [Boolean]
+  def widget?
+    group == :widget
   end
 
   def documented?

--- a/lib/template/swift_source.rb
+++ b/lib/template/swift_source.rb
@@ -1,2 +1,114 @@
 class Template::SwiftSource < Template::Base
+  using StringRefinement
+
+  # cspell: disable
+  CONTENT = <<-CONTENT
+    |public protocol Event {}
+    |<% post_message_definitions_by_subgroup.each do |subgroup, post_message_definitions| %>
+    |public enum <%= event_group_type_name(post_message_definitions.first) %> {
+    |    <%- post_message_definitions.each do |post_message| -%>
+    |    public struct <%= payload_type_name(post_message) %>: Event {
+    |        <%- post_message.payload.each do |field| -%>
+    |        <%- if field.optional? -%>
+    |        public let <%= payload_property_name(field) %>: <%= payload_property_type(post_message, field) %>?
+    |        <%- else -%>
+    |        public let <%= payload_property_name(field) %>: <%= payload_property_type(post_message, field) %>
+    |        <%- end -%>
+    |        <%- end -%>
+    |    }
+    |    <%- end -%>
+    |}
+    |<%- end -%>
+    |
+    |<%- post_message_definitions.each do |post_message| -%>
+    |<%- post_message.payload.each do |field| -%>
+    |<%- if field.enum? -%>
+    |public enum <%= enum_type_name(post_message, field) %> {
+    |<%- field.type.each do |entry| -%>
+    |    case <%= entry.camel_case %>
+    |<%- end -%>
+    |}
+    |<%- elsif field.struct? %>
+    |public struct <%= enum_type_name(post_message, field) %> {
+    |    <%- field.struct_fields.each do |field| -%>
+    |    public let <%= payload_property_name(field) %>: <%= payload_property_type(post_message, field) %>
+    |    <%- end -%>
+    |}
+    |<%- end -%>
+    |<%- end -%>
+    |<%- end -%>
+  CONTENT
+  # cspell: enable
+
+  # @example
+  #
+  #   event_group_type_name(PostMessageDefinition.new(:widget, :generic, :ping))
+  #   # => "WidgetEvent"
+  #   event_group_type_name(PostMessageDefinition.new(:widget, :connect, :memberDeleted))
+  #   # => "ConnectWidgetEvent"
+  #   event_group_type_name(PostMessageDefinition.new(:entity, :account, :created))
+  #   # => "AccountEvent"
+  #
+  # @param [PostMessageDefinition] post_message
+  # @return [String]
+  def event_group_type_name(post_message)
+    if post_message.generic?
+      "WidgetEvent"
+    elsif post_message.client?
+      "ClientEvent"
+    elsif post_message.widget?
+      "#{post_message.subgroup.to_s.classify}WidgetEvent"
+    else
+      "#{post_message.subgroup.to_s.classify}Event"
+    end
+  end
+
+  # @example
+  #
+  #   payload_type_name(PostMessageDefinition.new(:widget, :connect, :memberDeleted))
+  #   # => "MemberDeleted"
+  #
+  # @param [PostMessageDefinition] post_message
+  # @return [String]
+  def payload_type_name(post_message)
+    post_message.label.to_s.classify.normalize_keywords
+  end
+
+  # @param [PostMessageDefinition::PayloadField] field
+  # @return [String]
+  def payload_property_name(field)
+    field.name.camel_case
+  end
+
+  # @example
+  #
+  #   payload_type_name(PostMessageDefinition.new(:widget, :connect, :stepChange),
+  #                     PostMessageDefinition::PayloadField.new(:initial_step, ["step1", "step2"]))
+  #   # => "ConnectInitialStep"
+  #
+  # @param [PostMessageDefinition] post_message
+  # @param [PostMessageDefinition::PayloadField] field
+  # @return [String]
+  def enum_type_name(post_message, field)
+    "#{post_message.subgroup}_#{post_message.label}_#{field.name}".classify
+  end
+
+  # @param [PostMessageDefinition] post_message
+  # @param [PostMessageDefinition::PayloadField] field
+  # @param [Symbol] type (default: type, supports: code, type)
+  # @return [String]
+  def payload_property_type(post_message, field, format = :type)
+    case [field.type, field.type_type, format]
+    in ["string", :string, :type]
+      "String"
+    in ["boolean", :string, :type]
+      "Bool"
+    in ["number", :string, :type]
+      "Double"
+    in [_, :array | :hash, :type]
+      enum_type_name(post_message, field)
+    else
+      raise StandardError, "unable to do a Swift #{format} conversion on `#{field.type}`"
+    end
+  end
 end

--- a/lib/template/swift_source.rb
+++ b/lib/template/swift_source.rb
@@ -23,13 +23,13 @@ class Template::SwiftSource < Template::Base
     |<%- post_message_definitions.each do |post_message| -%>
     |<%- post_message.payload.each do |field| -%>
     |<%- if field.enum? -%>
-    |public enum <%= enum_type_name(post_message, field) %> {
+    |public enum <%= payload_field_type_name(post_message, field) %> {
     |<%- field.type.each do |entry| -%>
     |    case <%= entry.camel_case %>
     |<%- end -%>
     |}
     |<%- elsif field.struct? %>
-    |public struct <%= enum_type_name(post_message, field) %> {
+    |public struct <%= payload_field_type_name(post_message, field) %> {
     |    <%- field.struct_fields.each do |field| -%>
     |    public let <%= payload_property_name(field) %>: <%= payload_property_type(post_message, field) %>
     |    <%- end -%>
@@ -82,14 +82,14 @@ class Template::SwiftSource < Template::Base
 
   # @example
   #
-  #   payload_type_name(PostMessageDefinition.new(:widget, :connect, :stepChange),
+  #   payload_type_name(PostMessageDefinition.new(:widget, :connect, :loaded),
   #                     PostMessageDefinition::PayloadField.new(:initial_step, ["step1", "step2"]))
-  #   # => "ConnectInitialStep"
+  #   # => "ConnectLoadedInitialStep"
   #
   # @param [PostMessageDefinition] post_message
   # @param [PostMessageDefinition::PayloadField] field
   # @return [String]
-  def enum_type_name(post_message, field)
+  def payload_field_type_name(post_message, field)
     "#{post_message.subgroup}_#{post_message.label}_#{field.name}".classify
   end
 
@@ -106,7 +106,7 @@ class Template::SwiftSource < Template::Base
     in ["number", :string, :type]
       "Double"
     in [_, :array | :hash, :type]
-      enum_type_name(post_message, field)
+      payload_field_type_name(post_message, field)
     else
       raise StandardError, "unable to do a Swift #{format} conversion on `#{field.type}`"
     end

--- a/packages/swift/Sources/Generated.swift
+++ b/packages/swift/Sources/Generated.swift
@@ -7,3 +7,141 @@
  * project.
  */
 
+public protocol Event {}
+
+public enum WidgetEvent {
+    public struct Load: Event {
+    }
+    public struct Ping: Event {
+        public let userGuid: String
+        public let sessionGuid: String
+    }
+    public struct Navigation: Event {
+        public let userGuid: String
+        public let sessionGuid: String
+        public let didGoBack: Bool
+    }
+    public struct FocusTrap: Event {
+        public let userGuid: String
+        public let sessionGuid: String
+    }
+}
+
+public enum ClientEvent {
+    public struct OAuthComplete: Event {
+        public let url: String
+    }
+}
+
+public enum ConnectWidgetEvent {
+    public struct Loaded: Event {
+        public let userGuid: String
+        public let sessionGuid: String
+        public let initialStep: ConnectLoadedInitialStep
+    }
+    public struct EnterCredentials: Event {
+        public let userGuid: String
+        public let sessionGuid: String
+        public let institution: ConnectEnterCredentialsInstitution
+    }
+    public struct InstitutionSearch: Event {
+        public let userGuid: String
+        public let sessionGuid: String
+        public let query: String
+    }
+    public struct SelectedInstitution: Event {
+        public let userGuid: String
+        public let sessionGuid: String
+        public let code: String
+        public let guid: String
+        public let name: String
+        public let url: String
+    }
+    public struct MemberConnected: Event {
+        public let userGuid: String
+        public let sessionGuid: String
+        public let memberGuid: String
+    }
+    public struct ConnectedPrimaryAction: Event {
+        public let userGuid: String
+        public let sessionGuid: String
+    }
+    public struct MemberDeleted: Event {
+        public let userGuid: String
+        public let sessionGuid: String
+        public let memberGuid: String
+    }
+    public struct CreateMemberError: Event {
+        public let userGuid: String
+        public let sessionGuid: String
+        public let institutionGuid: String
+        public let institutionCode: String
+    }
+    public struct MemberStatusUpdate: Event {
+        public let userGuid: String
+        public let sessionGuid: String
+        public let memberGuid: String
+        public let connectionStatus: Double
+    }
+    public struct OAuthError: Event {
+        public let userGuid: String
+        public let sessionGuid: String
+        public let memberGuid: String?
+    }
+    public struct OAuthRequested: Event {
+        public let userGuid: String
+        public let sessionGuid: String
+        public let url: String
+        public let memberGuid: String
+    }
+    public struct StepChange: Event {
+        public let userGuid: String
+        public let sessionGuid: String
+        public let previous: String
+        public let current: String
+    }
+    public struct SubmitMFA: Event {
+        public let userGuid: String
+        public let sessionGuid: String
+        public let memberGuid: String
+    }
+    public struct UpdateCredentials: Event {
+        public let userGuid: String
+        public let sessionGuid: String
+        public let memberGuid: String
+        public let institution: ConnectUpdateCredentialsInstitution
+    }
+}
+
+public enum PulseWidgetEvent {
+    public struct OverdraftWarningCtaTransferFunds: Event {
+        public let accountGuid: String
+        public let amount: Double
+    }
+}
+
+public enum AccountEvent {
+    public struct Created: Event {
+        public let guid: String
+    }
+}
+
+public enum ConnectLoadedInitialStep {
+    case search
+    case selectMember
+    case enterCreds
+    case mfa
+    case connected
+    case loginError
+    case disclosure
+}
+
+public struct ConnectEnterCredentialsInstitution {
+    public let code: String
+    public let guid: String
+}
+
+public struct ConnectUpdateCredentialsInstitution {
+    public let code: String
+    public let guid: String
+}


### PR DESCRIPTION
Generating the structs used to represent the post message payloads. No post message parsing or dispatching in this PR, that'll come in a separate PR.