### PR TITLE
Excluding client post messages

### DIFF
--- a/lib/template/base.rb
+++ b/lib/template/base.rb
@@ -72,7 +72,7 @@ private
   # @return [Hash]
   def post_message_definitions_by_widget
     post_message_definitions_of_group(:widget).filter do |post_message|
-      !post_message.generic?
+      !post_message.generic? && !post_message.client?
     end.group_by(&:subgroup)
   end
 

--- a/packages/typescript/src/generated.ts
+++ b/packages/typescript/src/generated.ts
@@ -580,10 +580,6 @@ export type GenericPostMessageCallbackProps = {
 }
 
 
-export type ClientPostMessageCallbackProps<T> = WidgetPostMessageCallbackProps<T> & {
-  onOAuthComplete?: (payload: ClientOAuthCompletePayload) => void
-}
-
 export type ConnectPostMessageCallbackProps<T> = WidgetPostMessageCallbackProps<T> & {
   onLoaded?: (payload: ConnectLoadedPayload) => void
   onEnterCredentials?: (payload: ConnectEnterCredentialsPayload) => void
@@ -688,68 +684,6 @@ function dispatchWidgetInternalMessage<T>(payload: Payload, callbacks: WidgetPos
   }
 }
 
-
-/**
- * Dispatch a post message event that we got from a url change event for the
- * Client Widget.
- */
-export function dispatchClientLocationChangeEvent(url: string, callbacks: ClientPostMessageCallbackProps<string>) {
-  try {
-    dispatchOnMessage(url, callbacks)
-    const payload = buildPayloadFromUrl(url)
-    dispatchClientInternalMessage(payload, callbacks)
-  } catch (error) {
-    dispatchError(url, error, callbacks)
-  }
-}
-
-/**
- * Dispatch a post message event that we got from a window/document message for the
- * Client Widget.
- */
-export function dispatchClientPostMessageEvent(event: MessageEvent<MessageEventData>, callbacks: ClientPostMessageCallbackProps<MessageEvent<MessageEventData>>) {
-  try {
-    dispatchOnMessage(event, callbacks)
-    const payload = buildPayloadFromPostMessageEventData(event.data)
-    dispatchClientInternalMessage(payload, callbacks)
-  } catch (error) {
-    dispatchError(event, error, callbacks)
-  }
-}
-
-/**
- * Dispatch a validated internal message for the Client Widget.
- */
-function dispatchClientInternalMessage<T>(payload: Payload, callbacks: ClientPostMessageCallbackProps<T>) {
-  switch (payload.type) {
-    case Type.Load:
-      callbacks.onLoad?.(payload)
-      break
-
-    case Type.Ping:
-      callbacks.onPing?.(payload)
-      break
-
-    case Type.Navigation:
-      callbacks.onNavigation?.(payload)
-      break
-
-    case Type.FocusTrap:
-      callbacks.onFocusTrap?.(payload)
-      break
-
-    case Type.AccountCreated:
-      callbacks.onAccountCreated?.(payload)
-      break
-
-    case Type.ClientOAuthComplete:
-      callbacks.onOAuthComplete?.(payload)
-      break
-
-    default:
-      throw new PostMessageUnknownTypeError(payload.type)
-  }
-}
 
 /**
  * Dispatch a post message event that we got from a url change event for the


### PR DESCRIPTION
We were including post message definitions under the [`client` group](https://github.com/mxenabled/widget-post-message-definitions/blob/66bfb1b2987cbe1b47b2debec11fb5c071d2096c/lib/post_message_definition.yml) (which currently only includes one definition, `mx/client/oathComplete`) when generating widget-specific code. This isn't right, since client post messages are not specific to a widget. I found this issue when working on the Swift generator, which is where it was causing issues. Checking the updated TypeScript code, and from what I can tell, this won't cause problems in the SDKs that use that code.