### PR TITLE
Generating Swift event delegate protocols and extensions

### DIFF
--- a/lib/template/swift_source.rb
+++ b/lib/template/swift_source.rb
@@ -48,7 +48,7 @@ class Template::SwiftSource < Template::Base
     |    func widgetEvent(_ payload: <%= event_group_type_name(post_message) %>.<%= payload_type_name(post_message) %>)
     |<%- end -%>
     |<%- entity_post_message_definitions.each do |post_message| -%>
-    |    func widgetEvent(_ payload: <%= event_group_type_name(post_message) %>.<%= payload_type_name(post_message) %>)
+    |    /* func widgetEvent(_ payload: <%= event_group_type_name(post_message) %>.<%= payload_type_name(post_message) %>) */
     |<%- end -%>
     |}
     |
@@ -58,7 +58,7 @@ class Template::SwiftSource < Template::Base
     |    func widgetEvent(_: <%= event_group_type_name(post_message) %>.<%= payload_type_name(post_message) %>) {}
     |<%- end -%>
     |<%- entity_post_message_definitions.each do |post_message| -%>
-    |    func widgetEvent(_: <%= event_group_type_name(post_message) %>.<%= payload_type_name(post_message) %>) {}
+    |    /* func widgetEvent(_: <%= event_group_type_name(post_message) %>.<%= payload_type_name(post_message) %>) {} */
     |<%- end -%>
     |}
     |<%- post_message_definitions_by_widget.each do |subgroup, post_messages| %>

--- a/lib/template/swift_source.rb
+++ b/lib/template/swift_source.rb
@@ -47,8 +47,10 @@ class Template::SwiftSource < Template::Base
     |<%- generic_post_message_definitions.each do |post_message| -%>
     |    func widgetEvent(_ payload: <%= event_group_type_name(post_message) %>.<%= payload_type_name(post_message) %>)
     |<%- end -%>
+    |<%- if false -%>
     |<%- entity_post_message_definitions.each do |post_message| -%>
-    |    /* func widgetEvent(_ payload: <%= event_group_type_name(post_message) %>.<%= payload_type_name(post_message) %>) */
+    |    func widgetEvent(_ payload: <%= event_group_type_name(post_message) %>.<%= payload_type_name(post_message) %>)
+    |<%- end -%>
     |<%- end -%>
     |}
     |
@@ -57,8 +59,10 @@ class Template::SwiftSource < Template::Base
     |<%- generic_post_message_definitions.each do |post_message| -%>
     |    func widgetEvent(_: <%= event_group_type_name(post_message) %>.<%= payload_type_name(post_message) %>) {}
     |<%- end -%>
+    |<%- if false -%>
     |<%- entity_post_message_definitions.each do |post_message| -%>
-    |    /* func widgetEvent(_: <%= event_group_type_name(post_message) %>.<%= payload_type_name(post_message) %>) {} */
+    |    func widgetEvent(_: <%= event_group_type_name(post_message) %>.<%= payload_type_name(post_message) %>) {}
+    |<%- end -%>
     |<%- end -%>
     |}
     |<%- post_message_definitions_by_widget.each do |subgroup, post_messages| %>

--- a/packages/swift/Sources/Generated.swift
+++ b/packages/swift/Sources/Generated.swift
@@ -9,6 +9,8 @@
 
 public protocol Event {}
 
+/** Payloads **/
+
 public enum WidgetEvent {
     public struct Load: Event {
     }
@@ -144,4 +146,66 @@ public struct ConnectEnterCredentialsInstitution {
 public struct ConnectUpdateCredentialsInstitution {
     public let code: String
     public let guid: String
+}
+
+/** Delegates **/
+
+public protocol WidgetEventDelegate: NSObjectProtocol {
+    func widgetEvent(_ payload: Event)
+    func widgetEvent(_ payload: WidgetEvent.Load)
+    func widgetEvent(_ payload: WidgetEvent.Ping)
+    func widgetEvent(_ payload: WidgetEvent.Navigation)
+    func widgetEvent(_ payload: WidgetEvent.FocusTrap)
+    func widgetEvent(_ payload: AccountEvent.Created)
+}
+
+public extension WidgetEventDelegate {
+    func widgetEvent(_ payload: Event) {}
+    func widgetEvent(_: WidgetEvent.Load) {}
+    func widgetEvent(_: WidgetEvent.Ping) {}
+    func widgetEvent(_: WidgetEvent.Navigation) {}
+    func widgetEvent(_: WidgetEvent.FocusTrap) {}
+    func widgetEvent(_: AccountEvent.Created) {}
+}
+
+public protocol ConnectWidgetEventDelegate: WidgetEventDelegate {
+    func widgetEvent(_ payload: ConnectWidgetEvent.Loaded)
+    func widgetEvent(_ payload: ConnectWidgetEvent.EnterCredentials)
+    func widgetEvent(_ payload: ConnectWidgetEvent.InstitutionSearch)
+    func widgetEvent(_ payload: ConnectWidgetEvent.SelectedInstitution)
+    func widgetEvent(_ payload: ConnectWidgetEvent.MemberConnected)
+    func widgetEvent(_ payload: ConnectWidgetEvent.ConnectedPrimaryAction)
+    func widgetEvent(_ payload: ConnectWidgetEvent.MemberDeleted)
+    func widgetEvent(_ payload: ConnectWidgetEvent.CreateMemberError)
+    func widgetEvent(_ payload: ConnectWidgetEvent.MemberStatusUpdate)
+    func widgetEvent(_ payload: ConnectWidgetEvent.OAuthError)
+    func widgetEvent(_ payload: ConnectWidgetEvent.OAuthRequested)
+    func widgetEvent(_ payload: ConnectWidgetEvent.StepChange)
+    func widgetEvent(_ payload: ConnectWidgetEvent.SubmitMFA)
+    func widgetEvent(_ payload: ConnectWidgetEvent.UpdateCredentials)
+}
+
+public extension ConnectWidgetEventDelegate {
+    func widgetEvent(_: ConnectWidgetEvent.Loaded) {}
+    func widgetEvent(_: ConnectWidgetEvent.EnterCredentials) {}
+    func widgetEvent(_: ConnectWidgetEvent.InstitutionSearch) {}
+    func widgetEvent(_: ConnectWidgetEvent.SelectedInstitution) {}
+    func widgetEvent(_: ConnectWidgetEvent.MemberConnected) {}
+    func widgetEvent(_: ConnectWidgetEvent.ConnectedPrimaryAction) {}
+    func widgetEvent(_: ConnectWidgetEvent.MemberDeleted) {}
+    func widgetEvent(_: ConnectWidgetEvent.CreateMemberError) {}
+    func widgetEvent(_: ConnectWidgetEvent.MemberStatusUpdate) {}
+    func widgetEvent(_: ConnectWidgetEvent.OAuthError) {}
+    func widgetEvent(_: ConnectWidgetEvent.OAuthRequested) {}
+    func widgetEvent(_: ConnectWidgetEvent.StepChange) {}
+    func widgetEvent(_: ConnectWidgetEvent.SubmitMFA) {}
+    func widgetEvent(_: ConnectWidgetEvent.UpdateCredentials) {}
+}
+
+public protocol PulseWidgetEventDelegate: WidgetEventDelegate {
+    func widgetEvent(_ payload: PulseWidgetEvent.OverdraftWarningCtaTransferFunds)
+}
+
+public extension PulseWidgetEventDelegate {
+    func widgetEvent(_: PulseWidgetEvent.OverdraftWarningCtaTransferFunds) {}
 }

--- a/packages/swift/Sources/Generated.swift
+++ b/packages/swift/Sources/Generated.swift
@@ -156,7 +156,6 @@ public protocol WidgetEventDelegate: NSObjectProtocol {
     func widgetEvent(_ payload: WidgetEvent.Ping)
     func widgetEvent(_ payload: WidgetEvent.Navigation)
     func widgetEvent(_ payload: WidgetEvent.FocusTrap)
-    /* func widgetEvent(_ payload: AccountEvent.Created) */
 }
 
 public extension WidgetEventDelegate {
@@ -165,7 +164,6 @@ public extension WidgetEventDelegate {
     func widgetEvent(_: WidgetEvent.Ping) {}
     func widgetEvent(_: WidgetEvent.Navigation) {}
     func widgetEvent(_: WidgetEvent.FocusTrap) {}
-    /* func widgetEvent(_: AccountEvent.Created) {} */
 }
 
 public protocol ConnectWidgetEventDelegate: WidgetEventDelegate {

--- a/packages/swift/Sources/Generated.swift
+++ b/packages/swift/Sources/Generated.swift
@@ -156,7 +156,7 @@ public protocol WidgetEventDelegate: NSObjectProtocol {
     func widgetEvent(_ payload: WidgetEvent.Ping)
     func widgetEvent(_ payload: WidgetEvent.Navigation)
     func widgetEvent(_ payload: WidgetEvent.FocusTrap)
-    func widgetEvent(_ payload: AccountEvent.Created)
+    /* func widgetEvent(_ payload: AccountEvent.Created) */
 }
 
 public extension WidgetEventDelegate {
@@ -165,7 +165,7 @@ public extension WidgetEventDelegate {
     func widgetEvent(_: WidgetEvent.Ping) {}
     func widgetEvent(_: WidgetEvent.Navigation) {}
     func widgetEvent(_: WidgetEvent.FocusTrap) {}
-    func widgetEvent(_: AccountEvent.Created) {}
+    /* func widgetEvent(_: AccountEvent.Created) {} */
 }
 
 public protocol ConnectWidgetEventDelegate: WidgetEventDelegate {


### PR DESCRIPTION
These are the interfaces used by the SDK users that want to implement post message handlers and the internal dispatchers in the SDK.

You may notice I'm not generating entity handlers yet ([here](https://github.com/mxenabled/widget-post-message-definitions/pull/30/files#diff-bdbc7ecbf81398e3219d1219993057e73f2829fa40571c1d7299132a0e3fa42cR50-R54
) and [here](https://github.com/mxenabled/widget-post-message-definitions/pull/30/files#diff-bdbc7ecbf81398e3219d1219993057e73f2829fa40571c1d7299132a0e3fa42cR62-R66)), that's because those definitions are not complete. I'd like to add those fully, then introduce these.