### PR TITLE
Updating payload definitions so that they can be JSON decoded

### DIFF
--- a/lib/template/swift_source.rb
+++ b/lib/template/swift_source.rb
@@ -3,7 +3,7 @@ class Template::SwiftSource < Template::Base
 
   # cspell: disable
   CONTENT = <<-CONTENT
-    |public protocol Event {}
+    |public protocol Event: Codable {}
     |
     |/** Payloads **/
     |<% post_message_definitions_by_subgroup.each do |subgroup, post_message_definitions| %>
@@ -12,9 +12,9 @@ class Template::SwiftSource < Template::Base
     |    public struct <%= payload_type_name(post_message) %>: Event {
     |        <%- post_message.payload.each do |field| -%>
     |        <%- if field.optional? -%>
-    |        public let <%= payload_property_name(field) %>: <%= payload_property_type(post_message, field) %>?
+    |        public var <%= payload_property_name(field) %>: <%= payload_property_type(post_message, field) %>?
     |        <%- else -%>
-    |        public let <%= payload_property_name(field) %>: <%= payload_property_type(post_message, field) %>
+    |        public var <%= payload_property_name(field) %>: <%= payload_property_type(post_message, field) %>
     |        <%- end -%>
     |        <%- end -%>
     |    }
@@ -25,13 +25,13 @@ class Template::SwiftSource < Template::Base
     |<%- post_message_definitions.each do |post_message| -%>
     |<%- post_message.payload.each do |field| -%>
     |<%- if field.enum? -%>
-    |public enum <%= payload_field_type_name(post_message, field) %> {
+    |public enum <%= payload_field_type_name(post_message, field) %>: Codable {
     |<%- field.type.each do |entry| -%>
     |    case <%= entry.camel_case %>
     |<%- end -%>
     |}
     |<%- elsif field.struct? %>
-    |public struct <%= payload_field_type_name(post_message, field) %> {
+    |public struct <%= payload_field_type_name(post_message, field) %>: Codable {
     |    <%- field.struct_fields.each do |field| -%>
     |    public let <%= payload_property_name(field) %>: <%= payload_property_type(post_message, field) %>
     |    <%- end -%>

--- a/packages/swift/Sources/Generated.swift
+++ b/packages/swift/Sources/Generated.swift
@@ -7,7 +7,7 @@
  * project.
  */
 
-public protocol Event {}
+public protocol Event: Codable {}
 
 /** Payloads **/
 
@@ -15,120 +15,120 @@ public enum WidgetEvent {
     public struct Load: Event {
     }
     public struct Ping: Event {
-        public let userGuid: String
-        public let sessionGuid: String
+        public var userGuid: String
+        public var sessionGuid: String
     }
     public struct Navigation: Event {
-        public let userGuid: String
-        public let sessionGuid: String
-        public let didGoBack: Bool
+        public var userGuid: String
+        public var sessionGuid: String
+        public var didGoBack: Bool
     }
     public struct FocusTrap: Event {
-        public let userGuid: String
-        public let sessionGuid: String
+        public var userGuid: String
+        public var sessionGuid: String
     }
 }
 
 public enum ClientEvent {
     public struct OAuthComplete: Event {
-        public let url: String
+        public var url: String
     }
 }
 
 public enum ConnectWidgetEvent {
     public struct Loaded: Event {
-        public let userGuid: String
-        public let sessionGuid: String
-        public let initialStep: ConnectLoadedInitialStep
+        public var userGuid: String
+        public var sessionGuid: String
+        public var initialStep: ConnectLoadedInitialStep
     }
     public struct EnterCredentials: Event {
-        public let userGuid: String
-        public let sessionGuid: String
-        public let institution: ConnectEnterCredentialsInstitution
+        public var userGuid: String
+        public var sessionGuid: String
+        public var institution: ConnectEnterCredentialsInstitution
     }
     public struct InstitutionSearch: Event {
-        public let userGuid: String
-        public let sessionGuid: String
-        public let query: String
+        public var userGuid: String
+        public var sessionGuid: String
+        public var query: String
     }
     public struct SelectedInstitution: Event {
-        public let userGuid: String
-        public let sessionGuid: String
-        public let code: String
-        public let guid: String
-        public let name: String
-        public let url: String
+        public var userGuid: String
+        public var sessionGuid: String
+        public var code: String
+        public var guid: String
+        public var name: String
+        public var url: String
     }
     public struct MemberConnected: Event {
-        public let userGuid: String
-        public let sessionGuid: String
-        public let memberGuid: String
+        public var userGuid: String
+        public var sessionGuid: String
+        public var memberGuid: String
     }
     public struct ConnectedPrimaryAction: Event {
-        public let userGuid: String
-        public let sessionGuid: String
+        public var userGuid: String
+        public var sessionGuid: String
     }
     public struct MemberDeleted: Event {
-        public let userGuid: String
-        public let sessionGuid: String
-        public let memberGuid: String
+        public var userGuid: String
+        public var sessionGuid: String
+        public var memberGuid: String
     }
     public struct CreateMemberError: Event {
-        public let userGuid: String
-        public let sessionGuid: String
-        public let institutionGuid: String
-        public let institutionCode: String
+        public var userGuid: String
+        public var sessionGuid: String
+        public var institutionGuid: String
+        public var institutionCode: String
     }
     public struct MemberStatusUpdate: Event {
-        public let userGuid: String
-        public let sessionGuid: String
-        public let memberGuid: String
-        public let connectionStatus: Double
+        public var userGuid: String
+        public var sessionGuid: String
+        public var memberGuid: String
+        public var connectionStatus: Double
     }
     public struct OAuthError: Event {
-        public let userGuid: String
-        public let sessionGuid: String
-        public let memberGuid: String?
+        public var userGuid: String
+        public var sessionGuid: String
+        public var memberGuid: String?
     }
     public struct OAuthRequested: Event {
-        public let userGuid: String
-        public let sessionGuid: String
-        public let url: String
-        public let memberGuid: String
+        public var userGuid: String
+        public var sessionGuid: String
+        public var url: String
+        public var memberGuid: String
     }
     public struct StepChange: Event {
-        public let userGuid: String
-        public let sessionGuid: String
-        public let previous: String
-        public let current: String
+        public var userGuid: String
+        public var sessionGuid: String
+        public var previous: String
+        public var current: String
     }
     public struct SubmitMFA: Event {
-        public let userGuid: String
-        public let sessionGuid: String
-        public let memberGuid: String
+        public var userGuid: String
+        public var sessionGuid: String
+        public var memberGuid: String
     }
     public struct UpdateCredentials: Event {
-        public let userGuid: String
-        public let sessionGuid: String
-        public let memberGuid: String
-        public let institution: ConnectUpdateCredentialsInstitution
+        public var userGuid: String
+        public var sessionGuid: String
+        public var memberGuid: String
+        public var institution: ConnectUpdateCredentialsInstitution
     }
 }
 
 public enum PulseWidgetEvent {
     public struct OverdraftWarningCtaTransferFunds: Event {
-        public let accountGuid: String
-        public let amount: Double
+        public var accountGuid: String
+        public var amount: Double
     }
 }
 
 public enum AccountEvent {
     public struct Created: Event {
-        public let guid: String
+        public var guid: String
     }
 }
 
-public enum ConnectLoadedInitialStep {
+public enum ConnectLoadedInitialStep: Codable {
     case search
     case selectMember
     case enterCreds
@@ -138,12 +138,12 @@ public enum ConnectLoadedInitialStep {
     case disclosure
 }
 
-public struct ConnectEnterCredentialsInstitution {
+public struct ConnectEnterCredentialsInstitution: Codable {
     public let code: String
     public let guid: String
 }
 
-public struct ConnectUpdateCredentialsInstitution {
+public struct ConnectUpdateCredentialsInstitution: Codable {
     public let code: String
     public let guid: String
 }


### PR DESCRIPTION
Making the payload structs adhere to the `Codable` protocol which then lets us use them when parsing the metadata query parameters in the post message URL.