### PR TITLE
Decoding post message metadata

### DIFF
--- a/lib/template/base.rb
+++ b/lib/template/base.rb
@@ -76,6 +76,13 @@ private
     end.group_by(&:subgroup)
   end
 
+  # @return [Array<PostMessageDefinition>]
+  def widget_post_message_definitions_by_subgroup
+    post_message_definitions.filter do |post_message|
+      !post_message.client? && !post_message.entity?
+    end.group_by(&:subgroup)
+  end
+
   # @return [Hash]
   def post_message_definitions_by_group
     post_message_definitions.group_by(&:group)

--- a/lib/template/swift_source.rb
+++ b/lib/template/swift_source.rb
@@ -25,7 +25,7 @@ class Template::SwiftSource < Template::Base
     |<%- post_message_definitions.each do |post_message| -%>
     |<%- post_message.payload.each do |field| -%>
     |<%- if field.enum? -%>
-    |public enum <%= payload_field_type_name(post_message, field) %>: Codable {
+    |public enum <%= payload_field_type_name(post_message, field) %>: String, Codable {
     |<%- field.type.each do |entry| -%>
     |    case <%= entry.camel_case %>
     |<%- end -%>
@@ -87,11 +87,9 @@ class Template::SwiftSource < Template::Base
     |
     |extension Dispatcher {
     |    func extractMetadata(_ url: URL) -> Data? {
-    |        let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
-    |        let parameter = components?.queryItems?.first(where: { item in item.name == "metadata" })
-    |        let metadata = parameter?.value?.data(using: .utf8)!
-    |
-    |        return metadata
+    |        return URLComponents(url: url, resolvingAgainstBaseURL: false)?
+    |            .queryItems?.first(where: { item in item.name == "metadata" })?
+    |            .value?.data(using: .utf8)
     |    }
     |
     |    func decode<T>(_ typ: T.Type, _ data: Data) throws -> T where T: Decodable {

--- a/lib/template/swift_source.rb
+++ b/lib/template/swift_source.rb
@@ -78,6 +78,53 @@ class Template::SwiftSource < Template::Base
     |<%- end -%>
     |}
     |<%- end -%>
+    |
+    |/** Dispatchers **/
+    |
+    |protocol Dispatcher {
+    |    func dispatch(_: URL)
+    |}
+    |
+    |extension Dispatcher {
+    |    func extractMetadata(_ url: URL) -> Data? {
+    |        let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+    |        let parameter = components?.queryItems?.first(where: { item in item.name == "metadata" })
+    |        let metadata = parameter?.value?.data(using: .utf8)!
+    |
+    |        return metadata
+    |    }
+    |
+    |    func decode<T>(_ typ: T.Type, _ data: Data) throws -> T where T: Decodable {
+    |        let decoder = JSONDecoder()
+    |        decoder.keyDecodingStrategy = .convertFromSnakeCase
+    |        return try decoder.decode(typ, from: data)
+    |    }
+    |}
+    |<%- widget_post_message_definitions_by_subgroup.each do |subgroup, post_messages| %>
+    |class <%= dispatcher_group_type_name(post_messages.first) %>: Dispatcher {
+    |    let delegate: <%= delegate_group_type_name(post_messages.first) %>
+    |
+    |    init(_ delegate: <%= delegate_group_type_name(post_messages.first) %>) {
+    |        self.delegate = delegate
+    |    }
+    |
+    |    func dispatch(_ url: URL) {}
+    |
+    |    func parse(_ url: URL) -> Event? {
+    |        guard let metadata = extractMetadata(url) else {
+    |            return .none
+    |        }
+    |
+    |        switch (url.host, url.path) {
+    |        <%- with_generic_post_messages(subgroup, post_messages).each do |post_message| -%>
+    |        case ("<%= post_message_url_host(post_message) %>", "<%= post_message_url_path(post_message) %>"):
+    |            return try? decode(<%= event_group_type_name(post_message) %>.<%= payload_type_name(post_message) %>.self, metadata)
+    |        <%- end -%>
+    |        default: return .none
+    |        }
+    |    }
+    |}
+    |<%- end -%>
   CONTENT
   # cspell: enable
 
@@ -102,6 +149,12 @@ class Template::SwiftSource < Template::Base
     else
       "#{post_message.subgroup.to_s.classify}Event"
     end
+  end
+
+  # @param [PostMessageDefinition] post_message
+  # @return [String]
+  def dispatcher_group_type_name(post_message)
+    "#{event_group_type_name(post_message)}Dispatcher"
   end
 
   # @param [PostMessageDefinition] post_message
@@ -156,6 +209,51 @@ class Template::SwiftSource < Template::Base
       payload_field_type_name(post_message, field)
     else
       raise StandardError, "unable to do a Swift #{format} conversion on `#{field.type}`"
+    end
+  end
+
+  # The expected URL host for a given post message.
+  #
+  # @example
+  #
+  #   post_message_url_host(PostMessageDefinition.new(:widget, :generic, :ping))
+  #   # => "ping"
+  #   post_message_url_host(PostMessageDefinition.new(:widget, :connect, :memberDeleted))
+  #   # => "connect"
+  #
+  # @param [PostMessageDefinition] post_message
+  # @return [String]
+  def post_message_url_host(post_message)
+    post_message.generic? ? post_message.label.to_s : post_message.subgroup.to_s
+  end
+
+  # The expected URL path for a given post message.
+  #
+  # @example
+  #
+  #   post_message_url_path(PostMessageDefinition.new(:widget, :generic, :ping))
+  #   # => ""
+  #   post_message_url_path(PostMessageDefinition.new(:widget, :connect, :memberDeleted))
+  #   # => "/memberDeleted"
+  #
+  # @param [PostMessageDefinition] post_message
+  # @return [String]
+  def post_message_url_path(post_message)
+    post_message.generic? ? "" : "/#{post_message.label}"
+  end
+
+  # This method is used when you need to concatenate a list of widget specific
+  # post messages with the generic post messages. Useful when you need a list
+  # of all post messages that a widget _could_ possibly get.
+  #
+  # @param [Symbol] subgroup
+  # @param [Array<PostMessageDefinition>] post_message
+  # @return [Array<PostMessageDefinition>]
+  def with_generic_post_messages(subgroup, post_messages)
+    if subgroup == :generic
+      post_messages
+    else
+      generic_post_message_definitions + post_messages
     end
   end
 end

--- a/packages/swift/Sources/Generated.swift
+++ b/packages/swift/Sources/Generated.swift
@@ -128,7 +128,7 @@ public enum AccountEvent {
     }
 }
 
-public enum ConnectLoadedInitialStep: Codable {
+public enum ConnectLoadedInitialStep: String, Codable {
     case search
     case selectMember
     case enterCreds
@@ -216,11 +216,9 @@ protocol Dispatcher {
 
 extension Dispatcher {
     func extractMetadata(_ url: URL) -> Data? {
-        let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
-        let parameter = components?.queryItems?.first(where: { item in item.name == "metadata" })
-        let metadata = parameter?.value?.data(using: .utf8)!
-
-        return metadata
+        return URLComponents(url: url, resolvingAgainstBaseURL: false)?
+            .queryItems?.first(where: { item in item.name == "metadata" })?
+            .value?.data(using: .utf8)
     }
 
     func decode<T>(_ typ: T.Type, _ data: Data) throws -> T where T: Decodable {

--- a/packages/swift/Sources/Generated.swift
+++ b/packages/swift/Sources/Generated.swift
@@ -207,3 +207,139 @@ public protocol PulseWidgetEventDelegate: WidgetEventDelegate {
 public extension PulseWidgetEventDelegate {
     func widgetEvent(_: PulseWidgetEvent.OverdraftWarningCtaTransferFunds) {}
 }
+
+/** Dispatchers **/
+
+protocol Dispatcher {
+    func dispatch(_: URL)
+}
+
+extension Dispatcher {
+    func extractMetadata(_ url: URL) -> Data? {
+        let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        let parameter = components?.queryItems?.first(where: { item in item.name == "metadata" })
+        let metadata = parameter?.value?.data(using: .utf8)!
+
+        return metadata
+    }
+
+    func decode<T>(_ typ: T.Type, _ data: Data) throws -> T where T: Decodable {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return try decoder.decode(typ, from: data)
+    }
+}
+
+class WidgetEventDispatcher: Dispatcher {
+    let delegate: WidgetEventDelegate
+
+    init(_ delegate: WidgetEventDelegate) {
+        self.delegate = delegate
+    }
+
+    func dispatch(_ url: URL) {}
+
+    func parse(_ url: URL) -> Event? {
+        guard let metadata = extractMetadata(url) else {
+            return .none
+        }
+
+        switch (url.host, url.path) {
+        case ("load", ""):
+            return try? decode(WidgetEvent.Load.self, metadata)
+        case ("ping", ""):
+            return try? decode(WidgetEvent.Ping.self, metadata)
+        case ("navigation", ""):
+            return try? decode(WidgetEvent.Navigation.self, metadata)
+        case ("focusTrap", ""):
+            return try? decode(WidgetEvent.FocusTrap.self, metadata)
+        default: return .none
+        }
+    }
+}
+
+class ConnectWidgetEventDispatcher: Dispatcher {
+    let delegate: ConnectWidgetEventDelegate
+
+    init(_ delegate: ConnectWidgetEventDelegate) {
+        self.delegate = delegate
+    }
+
+    func dispatch(_ url: URL) {}
+
+    func parse(_ url: URL) -> Event? {
+        guard let metadata = extractMetadata(url) else {
+            return .none
+        }
+
+        switch (url.host, url.path) {
+        case ("load", ""):
+            return try? decode(WidgetEvent.Load.self, metadata)
+        case ("ping", ""):
+            return try? decode(WidgetEvent.Ping.self, metadata)
+        case ("navigation", ""):
+            return try? decode(WidgetEvent.Navigation.self, metadata)
+        case ("focusTrap", ""):
+            return try? decode(WidgetEvent.FocusTrap.self, metadata)
+        case ("connect", "/loaded"):
+            return try? decode(ConnectWidgetEvent.Loaded.self, metadata)
+        case ("connect", "/enterCredentials"):
+            return try? decode(ConnectWidgetEvent.EnterCredentials.self, metadata)
+        case ("connect", "/institutionSearch"):
+            return try? decode(ConnectWidgetEvent.InstitutionSearch.self, metadata)
+        case ("connect", "/selectedInstitution"):
+            return try? decode(ConnectWidgetEvent.SelectedInstitution.self, metadata)
+        case ("connect", "/memberConnected"):
+            return try? decode(ConnectWidgetEvent.MemberConnected.self, metadata)
+        case ("connect", "/connected/primaryAction"):
+            return try? decode(ConnectWidgetEvent.ConnectedPrimaryAction.self, metadata)
+        case ("connect", "/memberDeleted"):
+            return try? decode(ConnectWidgetEvent.MemberDeleted.self, metadata)
+        case ("connect", "/createMemberError"):
+            return try? decode(ConnectWidgetEvent.CreateMemberError.self, metadata)
+        case ("connect", "/memberStatusUpdate"):
+            return try? decode(ConnectWidgetEvent.MemberStatusUpdate.self, metadata)
+        case ("connect", "/oauthError"):
+            return try? decode(ConnectWidgetEvent.OAuthError.self, metadata)
+        case ("connect", "/oauthRequested"):
+            return try? decode(ConnectWidgetEvent.OAuthRequested.self, metadata)
+        case ("connect", "/stepChange"):
+            return try? decode(ConnectWidgetEvent.StepChange.self, metadata)
+        case ("connect", "/submitMFA"):
+            return try? decode(ConnectWidgetEvent.SubmitMFA.self, metadata)
+        case ("connect", "/updateCredentials"):
+            return try? decode(ConnectWidgetEvent.UpdateCredentials.self, metadata)
+        default: return .none
+        }
+    }
+}
+
+class PulseWidgetEventDispatcher: Dispatcher {
+    let delegate: PulseWidgetEventDelegate
+
+    init(_ delegate: PulseWidgetEventDelegate) {
+        self.delegate = delegate
+    }
+
+    func dispatch(_ url: URL) {}
+
+    func parse(_ url: URL) -> Event? {
+        guard let metadata = extractMetadata(url) else {
+            return .none
+        }
+
+        switch (url.host, url.path) {
+        case ("load", ""):
+            return try? decode(WidgetEvent.Load.self, metadata)
+        case ("ping", ""):
+            return try? decode(WidgetEvent.Ping.self, metadata)
+        case ("navigation", ""):
+            return try? decode(WidgetEvent.Navigation.self, metadata)
+        case ("focusTrap", ""):
+            return try? decode(WidgetEvent.FocusTrap.self, metadata)
+        case ("pulse", "/overdraftWarning/cta/transferFunds"):
+            return try? decode(PulseWidgetEvent.OverdraftWarningCtaTransferFunds.self, metadata)
+        default: return .none
+        }
+    }
+}


### PR DESCRIPTION
You'll notice there's an empty `dispatch` method, I had to add this so that so the `Dispatcher` protocol was being met and I could properly test this code. I kept it since that's what I'll work on next.