### PR TITLE
Prepping Swift code for unit tests

### DIFF
--- a/lib/post_message_definition.rb
+++ b/lib/post_message_definition.rb
@@ -41,7 +41,7 @@ class PostMessageDefinition
 
     # @return [Array<PayloadField>]
     def struct_fields
-      type.map do |(name, type)|
+      @struct_fields ||= type.map do |(name, type)|
         self.class.new(name, type)
       end
     end

--- a/lib/template/swift_source.rb
+++ b/lib/template/swift_source.rb
@@ -19,6 +19,13 @@ class Template::SwiftSource < Template::Base
     |        public var <%= payload_property_name(field) %>: <%= payload_property_type(post_message, field) %>
     |        <%- end -%>
     |        <%- end -%>
+    |
+    |        public static func == (lhs: <%= event_group_type_name(post_message) %>.<%= payload_type_name(post_message) %>, rhs: <%= event_group_type_name(post_message) %>.<%= payload_type_name(post_message) %>) -> Bool {
+    |            return true
+    |                <%- post_message.payload.each do |field| -%>
+    |                && lhs.<%= payload_property_name(field) %> == rhs.<%= payload_property_name(field) %>
+    |                <%- end -%>
+    |        }
     |    }
     |    <%- end -%>
     |}
@@ -37,6 +44,13 @@ class Template::SwiftSource < Template::Base
     |    <%- field.struct_fields.each do |field| -%>
     |    public let <%= payload_property_name(field) %>: <%= payload_property_type(post_message, field) %>
     |    <%- end -%>
+    |
+    |    public static func == (lhs: <%= payload_field_type_name(post_message, field) %>, rhs: <%= payload_field_type_name(post_message, field) %>) -> Bool {
+    |        return true
+    |            <%- field.struct_fields.each do |subfield| -%>
+    |            && lhs.<%= payload_property_name(subfield) %> == rhs.<%= payload_property_name(subfield) %>
+    |            <%- end -%>
+    |    }
     |}
     |<%- end -%>
     |<%- end -%>
@@ -44,7 +58,7 @@ class Template::SwiftSource < Template::Base
     |
     |/** Delegates **/
     |
-    |public protocol <%= delegate_group_type_name(generic_post_message_definitions.sample) %>: NSObjectProtocol {
+    |public protocol <%= delegate_group_type_name(generic_post_message_definitions.sample) %> {
     |    func widgetEvent(_ payload: Event)
     |<%- generic_post_message_definitions.each do |post_message| -%>
     |    func widgetEvent(_ payload: <%= event_group_type_name(post_message) %>.<%= payload_type_name(post_message) %>)
@@ -57,7 +71,7 @@ class Template::SwiftSource < Template::Base
     |}
     |
     |public extension <%= delegate_group_type_name(generic_post_message_definitions.sample) %> {
-    |    func widgetEvent(_ payload: Event) {}
+    |    func widgetEvent(_: Event) {}
     |<%- generic_post_message_definitions.each do |post_message| -%>
     |    func widgetEvent(_: <%= event_group_type_name(post_message) %>.<%= payload_type_name(post_message) %>) {}
     |<%- end -%>
@@ -94,7 +108,7 @@ class Template::SwiftSource < Template::Base
     |            .value?.data(using: .utf8)
     |    }
     |
-    |    func decode<T>(_ typ: T.Type, _ data: Data) throws -> T where T: Decodable {
+    |    func decode<T: Decodable>(_ typ: T.Type, _ data: Data) throws -> T {
     |        let decoder = JSONDecoder()
     |        decoder.keyDecodingStrategy = .convertFromSnakeCase
     |        return try decoder.decode(typ, from: data)

--- a/lib/template/swift_source.rb
+++ b/lib/template/swift_source.rb
@@ -21,10 +21,17 @@ class Template::SwiftSource < Template::Base
     |        <%- end -%>
     |
     |        public static func == (lhs: <%= event_group_type_name(post_message) %>.<%= payload_type_name(post_message) %>, rhs: <%= event_group_type_name(post_message) %>.<%= payload_type_name(post_message) %>) -> Bool {
+    |            <%- if post_message.payload.empty? -%>
     |            return true
-    |                <%- post_message.payload.each do |field| -%>
+    |            <%- else -%>
+    |            <%- post_message.payload.each do |field| -%>
+    |            <%- if field == post_message.payload.first -%>
+    |            return lhs.<%= payload_property_name(field) %> == rhs.<%= payload_property_name(field) %>
+    |            <%- else -%>
     |                && lhs.<%= payload_property_name(field) %> == rhs.<%= payload_property_name(field) %>
-    |                <%- end -%>
+    |            <%- end -%>
+    |            <%- end -%>
+    |            <%- end -%>
     |        }
     |    }
     |    <%- end -%>
@@ -46,10 +53,17 @@ class Template::SwiftSource < Template::Base
     |    <%- end -%>
     |
     |    public static func == (lhs: <%= payload_field_type_name(post_message, field) %>, rhs: <%= payload_field_type_name(post_message, field) %>) -> Bool {
+    |        <%- if field.struct_fields.empty? -%>
     |        return true
-    |            <%- field.struct_fields.each do |subfield| -%>
+    |        <%- else -%>
+    |        <%- field.struct_fields.each do |subfield| -%>
+    |        <%- if subfield == field.struct_fields.first -%>
+    |        return lhs.<%= payload_property_name(subfield) %> == rhs.<%= payload_property_name(subfield) %>
+    |        <%- else -%>
     |            && lhs.<%= payload_property_name(subfield) %> == rhs.<%= payload_property_name(subfield) %>
-    |            <%- end -%>
+    |        <%- end -%>
+    |        <%- end -%>
+    |        <%- end -%>
     |    }
     |}
     |<%- end -%>

--- a/packages/swift/Sources/Generated.swift
+++ b/packages/swift/Sources/Generated.swift
@@ -15,25 +15,53 @@ public protocol Event: Codable {}
 
 public enum WidgetEvent {
     public struct Load: Event {
+
+        public static func == (lhs: WidgetEvent.Load, rhs: WidgetEvent.Load) -> Bool {
+            return true
+        }
     }
     public struct Ping: Event {
         public var userGuid: String
         public var sessionGuid: String
+
+        public static func == (lhs: WidgetEvent.Ping, rhs: WidgetEvent.Ping) -> Bool {
+            return true
+                && lhs.userGuid == rhs.userGuid
+                && lhs.sessionGuid == rhs.sessionGuid
+        }
     }
     public struct Navigation: Event {
         public var userGuid: String
         public var sessionGuid: String
         public var didGoBack: Bool
+
+        public static func == (lhs: WidgetEvent.Navigation, rhs: WidgetEvent.Navigation) -> Bool {
+            return true
+                && lhs.userGuid == rhs.userGuid
+                && lhs.sessionGuid == rhs.sessionGuid
+                && lhs.didGoBack == rhs.didGoBack
+        }
     }
     public struct FocusTrap: Event {
         public var userGuid: String
         public var sessionGuid: String
+
+        public static func == (lhs: WidgetEvent.FocusTrap, rhs: WidgetEvent.FocusTrap) -> Bool {
+            return true
+                && lhs.userGuid == rhs.userGuid
+                && lhs.sessionGuid == rhs.sessionGuid
+        }
     }
 }
 
 public enum ClientEvent {
     public struct OAuthComplete: Event {
         public var url: String
+
+        public static func == (lhs: ClientEvent.OAuthComplete, rhs: ClientEvent.OAuthComplete) -> Bool {
+            return true
+                && lhs.url == rhs.url
+        }
     }
 }
 
@@ -42,16 +70,37 @@ public enum ConnectWidgetEvent {
         public var userGuid: String
         public var sessionGuid: String
         public var initialStep: ConnectLoadedInitialStep
+
+        public static func == (lhs: ConnectWidgetEvent.Loaded, rhs: ConnectWidgetEvent.Loaded) -> Bool {
+            return true
+                && lhs.userGuid == rhs.userGuid
+                && lhs.sessionGuid == rhs.sessionGuid
+                && lhs.initialStep == rhs.initialStep
+        }
     }
     public struct EnterCredentials: Event {
         public var userGuid: String
         public var sessionGuid: String
         public var institution: ConnectEnterCredentialsInstitution
+
+        public static func == (lhs: ConnectWidgetEvent.EnterCredentials, rhs: ConnectWidgetEvent.EnterCredentials) -> Bool {
+            return true
+                && lhs.userGuid == rhs.userGuid
+                && lhs.sessionGuid == rhs.sessionGuid
+                && lhs.institution == rhs.institution
+        }
     }
     public struct InstitutionSearch: Event {
         public var userGuid: String
         public var sessionGuid: String
         public var query: String
+
+        public static func == (lhs: ConnectWidgetEvent.InstitutionSearch, rhs: ConnectWidgetEvent.InstitutionSearch) -> Bool {
+            return true
+                && lhs.userGuid == rhs.userGuid
+                && lhs.sessionGuid == rhs.sessionGuid
+                && lhs.query == rhs.query
+        }
     }
     public struct SelectedInstitution: Event {
         public var userGuid: String
@@ -60,60 +109,144 @@ public enum ConnectWidgetEvent {
         public var guid: String
         public var name: String
         public var url: String
+
+        public static func == (lhs: ConnectWidgetEvent.SelectedInstitution, rhs: ConnectWidgetEvent.SelectedInstitution) -> Bool {
+            return true
+                && lhs.userGuid == rhs.userGuid
+                && lhs.sessionGuid == rhs.sessionGuid
+                && lhs.code == rhs.code
+                && lhs.guid == rhs.guid
+                && lhs.name == rhs.name
+                && lhs.url == rhs.url
+        }
     }
     public struct MemberConnected: Event {
         public var userGuid: String
         public var sessionGuid: String
         public var memberGuid: String
+
+        public static func == (lhs: ConnectWidgetEvent.MemberConnected, rhs: ConnectWidgetEvent.MemberConnected) -> Bool {
+            return true
+                && lhs.userGuid == rhs.userGuid
+                && lhs.sessionGuid == rhs.sessionGuid
+                && lhs.memberGuid == rhs.memberGuid
+        }
     }
     public struct ConnectedPrimaryAction: Event {
         public var userGuid: String
         public var sessionGuid: String
+
+        public static func == (lhs: ConnectWidgetEvent.ConnectedPrimaryAction, rhs: ConnectWidgetEvent.ConnectedPrimaryAction) -> Bool {
+            return true
+                && lhs.userGuid == rhs.userGuid
+                && lhs.sessionGuid == rhs.sessionGuid
+        }
     }
     public struct MemberDeleted: Event {
         public var userGuid: String
         public var sessionGuid: String
         public var memberGuid: String
+
+        public static func == (lhs: ConnectWidgetEvent.MemberDeleted, rhs: ConnectWidgetEvent.MemberDeleted) -> Bool {
+            return true
+                && lhs.userGuid == rhs.userGuid
+                && lhs.sessionGuid == rhs.sessionGuid
+                && lhs.memberGuid == rhs.memberGuid
+        }
     }
     public struct CreateMemberError: Event {
         public var userGuid: String
         public var sessionGuid: String
         public var institutionGuid: String
         public var institutionCode: String
+
+        public static func == (lhs: ConnectWidgetEvent.CreateMemberError, rhs: ConnectWidgetEvent.CreateMemberError) -> Bool {
+            return true
+                && lhs.userGuid == rhs.userGuid
+                && lhs.sessionGuid == rhs.sessionGuid
+                && lhs.institutionGuid == rhs.institutionGuid
+                && lhs.institutionCode == rhs.institutionCode
+        }
     }
     public struct MemberStatusUpdate: Event {
         public var userGuid: String
         public var sessionGuid: String
         public var memberGuid: String
         public var connectionStatus: Double
+
+        public static func == (lhs: ConnectWidgetEvent.MemberStatusUpdate, rhs: ConnectWidgetEvent.MemberStatusUpdate) -> Bool {
+            return true
+                && lhs.userGuid == rhs.userGuid
+                && lhs.sessionGuid == rhs.sessionGuid
+                && lhs.memberGuid == rhs.memberGuid
+                && lhs.connectionStatus == rhs.connectionStatus
+        }
     }
     public struct OAuthError: Event {
         public var userGuid: String
         public var sessionGuid: String
         public var memberGuid: String?
+
+        public static func == (lhs: ConnectWidgetEvent.OAuthError, rhs: ConnectWidgetEvent.OAuthError) -> Bool {
+            return true
+                && lhs.userGuid == rhs.userGuid
+                && lhs.sessionGuid == rhs.sessionGuid
+                && lhs.memberGuid == rhs.memberGuid
+        }
     }
     public struct OAuthRequested: Event {
         public var userGuid: String
         public var sessionGuid: String
         public var url: String
         public var memberGuid: String
+
+        public static func == (lhs: ConnectWidgetEvent.OAuthRequested, rhs: ConnectWidgetEvent.OAuthRequested) -> Bool {
+            return true
+                && lhs.userGuid == rhs.userGuid
+                && lhs.sessionGuid == rhs.sessionGuid
+                && lhs.url == rhs.url
+                && lhs.memberGuid == rhs.memberGuid
+        }
     }
     public struct StepChange: Event {
         public var userGuid: String
         public var sessionGuid: String
         public var previous: String
         public var current: String
+
+        public static func == (lhs: ConnectWidgetEvent.StepChange, rhs: ConnectWidgetEvent.StepChange) -> Bool {
+            return true
+                && lhs.userGuid == rhs.userGuid
+                && lhs.sessionGuid == rhs.sessionGuid
+                && lhs.previous == rhs.previous
+                && lhs.current == rhs.current
+        }
     }
     public struct SubmitMFA: Event {
         public var userGuid: String
         public var sessionGuid: String
         public var memberGuid: String
+
+        public static func == (lhs: ConnectWidgetEvent.SubmitMFA, rhs: ConnectWidgetEvent.SubmitMFA) -> Bool {
+            return true
+                && lhs.userGuid == rhs.userGuid
+                && lhs.sessionGuid == rhs.sessionGuid
+                && lhs.memberGuid == rhs.memberGuid
+        }
     }
     public struct UpdateCredentials: Event {
         public var userGuid: String
         public var sessionGuid: String
         public var memberGuid: String
         public var institution: ConnectUpdateCredentialsInstitution
+
+        public static func == (lhs: ConnectWidgetEvent.UpdateCredentials, rhs: ConnectWidgetEvent.UpdateCredentials) -> Bool {
+            return true
+                && lhs.userGuid == rhs.userGuid
+                && lhs.sessionGuid == rhs.sessionGuid
+                && lhs.memberGuid == rhs.memberGuid
+                && lhs.institution == rhs.institution
+        }
     }
 }
 
@@ -121,12 +254,23 @@ public enum PulseWidgetEvent {
     public struct OverdraftWarningCtaTransferFunds: Event {
         public var accountGuid: String
         public var amount: Double
+
+        public static func == (lhs: PulseWidgetEvent.OverdraftWarningCtaTransferFunds, rhs: PulseWidgetEvent.OverdraftWarningCtaTransferFunds) -> Bool {
+            return true
+                && lhs.accountGuid == rhs.accountGuid
+                && lhs.amount == rhs.amount
+        }
     }
 }
 
 public enum AccountEvent {
     public struct Created: Event {
         public var guid: String
+
+        public static func == (lhs: AccountEvent.Created, rhs: AccountEvent.Created) -> Bool {
+            return true
+                && lhs.guid == rhs.guid
+        }
     }
 }
 
@@ -143,16 +287,28 @@ public enum ConnectLoadedInitialStep: String, Codable {
 public struct ConnectEnterCredentialsInstitution: Codable {
     public let code: String
     public let guid: String
+
+    public static func == (lhs: ConnectEnterCredentialsInstitution, rhs: ConnectEnterCredentialsInstitution) -> Bool {
+        return true
+            && lhs.code == rhs.code
+            && lhs.guid == rhs.guid
+    }
 }
 
 public struct ConnectUpdateCredentialsInstitution: Codable {
     public let code: String
     public let guid: String
+
+    public static func == (lhs: ConnectUpdateCredentialsInstitution, rhs: ConnectUpdateCredentialsInstitution) -> Bool {
+        return true
+            && lhs.code == rhs.code
+            && lhs.guid == rhs.guid
+    }
 }
 
 /** Delegates **/
 
-public protocol WidgetEventDelegate: NSObjectProtocol {
+public protocol WidgetEventDelegate {
     func widgetEvent(_ payload: Event)
     func widgetEvent(_ payload: WidgetEvent.Load)
     func widgetEvent(_ payload: WidgetEvent.Ping)
@@ -161,7 +317,7 @@ public protocol WidgetEventDelegate: NSObjectProtocol {
 }
 
 public extension WidgetEventDelegate {
-    func widgetEvent(_ payload: Event) {}
+    func widgetEvent(_: Event) {}
     func widgetEvent(_: WidgetEvent.Load) {}
     func widgetEvent(_: WidgetEvent.Ping) {}
     func widgetEvent(_: WidgetEvent.Navigation) {}
@@ -223,7 +379,7 @@ extension Dispatcher {
             .value?.data(using: .utf8)
     }
 
-    func decode<T>(_ typ: T.Type, _ data: Data) throws -> T where T: Decodable {
+    func decode<T: Decodable>(_ typ: T.Type, _ data: Data) throws -> T {
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase
         return try decoder.decode(typ, from: data)

--- a/packages/swift/Sources/Generated.swift
+++ b/packages/swift/Sources/Generated.swift
@@ -25,8 +25,7 @@ public enum WidgetEvent {
         public var sessionGuid: String
 
         public static func == (lhs: WidgetEvent.Ping, rhs: WidgetEvent.Ping) -> Bool {
-            return true
-                && lhs.userGuid == rhs.userGuid
+            return lhs.userGuid == rhs.userGuid
                 && lhs.sessionGuid == rhs.sessionGuid
         }
     }
@@ -36,8 +35,7 @@ public enum WidgetEvent {
         public var didGoBack: Bool
 
         public static func == (lhs: WidgetEvent.Navigation, rhs: WidgetEvent.Navigation) -> Bool {
-            return true
-                && lhs.userGuid == rhs.userGuid
+            return lhs.userGuid == rhs.userGuid
                 && lhs.sessionGuid == rhs.sessionGuid
                 && lhs.didGoBack == rhs.didGoBack
         }
@@ -47,8 +45,7 @@ public enum WidgetEvent {
         public var sessionGuid: String
 
         public static func == (lhs: WidgetEvent.FocusTrap, rhs: WidgetEvent.FocusTrap) -> Bool {
-            return true
-                && lhs.userGuid == rhs.userGuid
+            return lhs.userGuid == rhs.userGuid
                 && lhs.sessionGuid == rhs.sessionGuid
         }
     }
@@ -59,8 +56,7 @@ public enum ClientEvent {
         public var url: String
 
         public static func == (lhs: ClientEvent.OAuthComplete, rhs: ClientEvent.OAuthComplete) -> Bool {
-            return true
-                && lhs.url == rhs.url
+            return lhs.url == rhs.url
         }
     }
 }
@@ -72,8 +68,7 @@ public enum ConnectWidgetEvent {
         public var initialStep: ConnectLoadedInitialStep
 
         public static func == (lhs: ConnectWidgetEvent.Loaded, rhs: ConnectWidgetEvent.Loaded) -> Bool {
-            return true
-                && lhs.userGuid == rhs.userGuid
+            return lhs.userGuid == rhs.userGuid
                 && lhs.sessionGuid == rhs.sessionGuid
                 && lhs.initialStep == rhs.initialStep
         }
@@ -84,8 +79,7 @@ public enum ConnectWidgetEvent {
         public var institution: ConnectEnterCredentialsInstitution
 
         public static func == (lhs: ConnectWidgetEvent.EnterCredentials, rhs: ConnectWidgetEvent.EnterCredentials) -> Bool {
-            return true
-                && lhs.userGuid == rhs.userGuid
+            return lhs.userGuid == rhs.userGuid
                 && lhs.sessionGuid == rhs.sessionGuid
                 && lhs.institution == rhs.institution
         }
@@ -96,8 +90,7 @@ public enum ConnectWidgetEvent {
         public var query: String
 
         public static func == (lhs: ConnectWidgetEvent.InstitutionSearch, rhs: ConnectWidgetEvent.InstitutionSearch) -> Bool {
-            return true
-                && lhs.userGuid == rhs.userGuid
+            return lhs.userGuid == rhs.userGuid
                 && lhs.sessionGuid == rhs.sessionGuid
                 && lhs.query == rhs.query
         }
@@ -111,8 +104,7 @@ public enum ConnectWidgetEvent {
         public var url: String
 
         public static func == (lhs: ConnectWidgetEvent.SelectedInstitution, rhs: ConnectWidgetEvent.SelectedInstitution) -> Bool {
-            return true
-                && lhs.userGuid == rhs.userGuid
+            return lhs.userGuid == rhs.userGuid
                 && lhs.sessionGuid == rhs.sessionGuid
                 && lhs.code == rhs.code
                 && lhs.guid == rhs.guid
@@ -126,8 +118,7 @@ public enum ConnectWidgetEvent {
         public var memberGuid: String
 
         public static func == (lhs: ConnectWidgetEvent.MemberConnected, rhs: ConnectWidgetEvent.MemberConnected) -> Bool {
-            return true
-                && lhs.userGuid == rhs.userGuid
+            return lhs.userGuid == rhs.userGuid
                 && lhs.sessionGuid == rhs.sessionGuid
                 && lhs.memberGuid == rhs.memberGuid
         }
@@ -137,8 +128,7 @@ public enum ConnectWidgetEvent {
         public var sessionGuid: String
 
         public static func == (lhs: ConnectWidgetEvent.ConnectedPrimaryAction, rhs: ConnectWidgetEvent.ConnectedPrimaryAction) -> Bool {
-            return true
-                && lhs.userGuid == rhs.userGuid
+            return lhs.userGuid == rhs.userGuid
                 && lhs.sessionGuid == rhs.sessionGuid
         }
     }
@@ -148,8 +138,7 @@ public enum ConnectWidgetEvent {
         public var memberGuid: String
 
         public static func == (lhs: ConnectWidgetEvent.MemberDeleted, rhs: ConnectWidgetEvent.MemberDeleted) -> Bool {
-            return true
-                && lhs.userGuid == rhs.userGuid
+            return lhs.userGuid == rhs.userGuid
                 && lhs.sessionGuid == rhs.sessionGuid
                 && lhs.memberGuid == rhs.memberGuid
         }
@@ -161,8 +150,7 @@ public enum ConnectWidgetEvent {
         public var institutionCode: String
 
         public static func == (lhs: ConnectWidgetEvent.CreateMemberError, rhs: ConnectWidgetEvent.CreateMemberError) -> Bool {
-            return true
-                && lhs.userGuid == rhs.userGuid
+            return lhs.userGuid == rhs.userGuid
                 && lhs.sessionGuid == rhs.sessionGuid
                 && lhs.institutionGuid == rhs.institutionGuid
                 && lhs.institutionCode == rhs.institutionCode
@@ -175,8 +163,7 @@ public enum ConnectWidgetEvent {
         public var connectionStatus: Double
 
         public static func == (lhs: ConnectWidgetEvent.MemberStatusUpdate, rhs: ConnectWidgetEvent.MemberStatusUpdate) -> Bool {
-            return true
-                && lhs.userGuid == rhs.userGuid
+            return lhs.userGuid == rhs.userGuid
                 && lhs.sessionGuid == rhs.sessionGuid
                 && lhs.memberGuid == rhs.memberGuid
                 && lhs.connectionStatus == rhs.connectionStatus
@@ -188,8 +175,7 @@ public enum ConnectWidgetEvent {
         public var memberGuid: String?
 
         public static func == (lhs: ConnectWidgetEvent.OAuthError, rhs: ConnectWidgetEvent.OAuthError) -> Bool {
-            return true
-                && lhs.userGuid == rhs.userGuid
+            return lhs.userGuid == rhs.userGuid
                 && lhs.sessionGuid == rhs.sessionGuid
                 && lhs.memberGuid == rhs.memberGuid
         }
@@ -201,8 +187,7 @@ public enum ConnectWidgetEvent {
         public var memberGuid: String
 
         public static func == (lhs: ConnectWidgetEvent.OAuthRequested, rhs: ConnectWidgetEvent.OAuthRequested) -> Bool {
-            return true
-                && lhs.userGuid == rhs.userGuid
+            return lhs.userGuid == rhs.userGuid
                 && lhs.sessionGuid == rhs.sessionGuid
                 && lhs.url == rhs.url
                 && lhs.memberGuid == rhs.memberGuid
@@ -215,8 +200,7 @@ public enum ConnectWidgetEvent {
         public var current: String
 
         public static func == (lhs: ConnectWidgetEvent.StepChange, rhs: ConnectWidgetEvent.StepChange) -> Bool {
-            return true
-                && lhs.userGuid == rhs.userGuid
+            return lhs.userGuid == rhs.userGuid
                 && lhs.sessionGuid == rhs.sessionGuid
                 && lhs.previous == rhs.previous
                 && lhs.current == rhs.current
@@ -228,8 +212,7 @@ public enum ConnectWidgetEvent {
         public var memberGuid: String
 
         public static func == (lhs: ConnectWidgetEvent.SubmitMFA, rhs: ConnectWidgetEvent.SubmitMFA) -> Bool {
-            return true
-                && lhs.userGuid == rhs.userGuid
+            return lhs.userGuid == rhs.userGuid
                 && lhs.sessionGuid == rhs.sessionGuid
                 && lhs.memberGuid == rhs.memberGuid
         }
@@ -241,8 +224,7 @@ public enum ConnectWidgetEvent {
         public var institution: ConnectUpdateCredentialsInstitution
 
         public static func == (lhs: ConnectWidgetEvent.UpdateCredentials, rhs: ConnectWidgetEvent.UpdateCredentials) -> Bool {
-            return true
-                && lhs.userGuid == rhs.userGuid
+            return lhs.userGuid == rhs.userGuid
                 && lhs.sessionGuid == rhs.sessionGuid
                 && lhs.memberGuid == rhs.memberGuid
                 && lhs.institution == rhs.institution
@@ -256,8 +238,7 @@ public enum PulseWidgetEvent {
         public var amount: Double
 
         public static func == (lhs: PulseWidgetEvent.OverdraftWarningCtaTransferFunds, rhs: PulseWidgetEvent.OverdraftWarningCtaTransferFunds) -> Bool {
-            return true
-                && lhs.accountGuid == rhs.accountGuid
+            return lhs.accountGuid == rhs.accountGuid
                 && lhs.amount == rhs.amount
         }
     }
@@ -268,8 +249,7 @@ public enum AccountEvent {
         public var guid: String
 
         public static func == (lhs: AccountEvent.Created, rhs: AccountEvent.Created) -> Bool {
-            return true
-                && lhs.guid == rhs.guid
+            return lhs.guid == rhs.guid
         }
     }
 }
@@ -289,8 +269,7 @@ public struct ConnectEnterCredentialsInstitution: Codable {
     public let guid: String
 
     public static func == (lhs: ConnectEnterCredentialsInstitution, rhs: ConnectEnterCredentialsInstitution) -> Bool {
-        return true
-            && lhs.code == rhs.code
+        return lhs.code == rhs.code
             && lhs.guid == rhs.guid
     }
 }
@@ -300,8 +279,7 @@ public struct ConnectUpdateCredentialsInstitution: Codable {
     public let guid: String
 
     public static func == (lhs: ConnectUpdateCredentialsInstitution, rhs: ConnectUpdateCredentialsInstitution) -> Bool {
-        return true
-            && lhs.code == rhs.code
+        return lhs.code == rhs.code
             && lhs.guid == rhs.guid
     }
 }


### PR DESCRIPTION
- Overloading the `==` operator in generated structs so that we can easily compare dispatched and received payloads in tests.
- Removing `NSObjectProtocol` inheritance from base delegate protocol to fix a mocking issue. We don't need our delegate protocols to inherit `NSObjectProtocol` in the first place.
- Removing name of unused parameter. Not necessary but makes the code more consistent.