### PR TITLE
Running Swift unit tests in CI

### DIFF
--- a/.github/workflows/build-swift-package.yml
+++ b/.github/workflows/build-swift-package.yml
@@ -25,5 +25,5 @@ jobs:
     - run: swift build
       working-directory: packages/swift
 
-    - run: swift build
+    - run: swift test
       working-directory: packages/swift

--- a/.github/workflows/build-swift-package.yml
+++ b/.github/workflows/build-swift-package.yml
@@ -15,6 +15,15 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    - uses: actions/cache@v3
+      with:
+        path: packages/swift/.build
+        key: ${{ runner.os }}-spm-${{ hashFiles('packages/swift/Package.resolved') }}
+        restore-keys: |
+          ${{ runner.os }}-spm-
+
+    - run: swift build
+      working-directory: packages/swift
 
     - run: swift build
       working-directory: packages/swift

--- a/packages/swift/.gitignore
+++ b/packages/swift/.gitignore
@@ -1,1 +1,2 @@
 .build
+.mockingbird

--- a/packages/swift/Package.resolved
+++ b/packages/swift/Package.resolved
@@ -1,0 +1,25 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "Mockingbird",
+        "repositoryURL": "https://github.com/birdrides/mockingbird",
+        "state": {
+          "branch": null,
+          "revision": "3adde74fee6ded87a731977487135aa47cfcbe13",
+          "version": "0.19.2"
+        }
+      },
+      {
+        "package": "Quick",
+        "repositoryURL": "https://github.com/Quick/Quick",
+        "state": {
+          "branch": null,
+          "revision": "f9d519828bb03dfc8125467d8f7b93131951124c",
+          "version": "5.0.1"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/packages/swift/Package.swift
+++ b/packages/swift/Package.swift
@@ -3,12 +3,29 @@ import PackageDescription
 
 let package = Package(
     name: "MXPostMessageDefinitions",
-    platforms: [.iOS(.v12)],
+    platforms: [
+        .iOS(.v12),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/Quick/Quick", from: "5.0.0"),
+        .package(name: "Mockingbird", url: "https://github.com/birdrides/mockingbird", from: "0.19.0"),
+    ],
     targets: [
         .target(
             name: "MXPostMessageDefinitions",
             path: "Sources"
         ),
+        .testTarget(
+            name: "MXPostMessageDefinitionsTests",
+            dependencies: [
+                "MXPostMessageDefinitions",
+                "Quick",
+                "Mockingbird"
+            ],
+            path: "Tests"
+        ),
     ],
-    swiftLanguageVersions: [.v5]
+    swiftLanguageVersions: [
+        .v5,
+    ]
 )

--- a/packages/swift/Tests/DispatchingEventsToDelegateTests.swift
+++ b/packages/swift/Tests/DispatchingEventsToDelegateTests.swift
@@ -1,0 +1,8 @@
+import Foundation
+import Mockingbird
+import Quick
+
+@testable import MXPostMessageDefinitions
+
+class DispatchingEventsToDelegateTests: QuickSpec {
+}


### PR DESCRIPTION
Installing dependencies required for running unit tests and updating CI to run the Swift tests. In addition, I'm adding a test target to the project (so we can build), an empty test class (so there's something to build/run), and caching the build output in the CI to speed things up.

The two dependencies I'm bringing in are [Quick](https://github.com/Quick/Quick) and [Mockingbird](https://github.com/birdrides/mockingbird). Quick is the test framework (which is a little nicer than the default XCTest) and Mockingbird is a mocking library that I use to mock the delegates in the tests. Mockingbird generates code, I'll add that in a future PR.

**Edit**: showing that the caching is working: [this is the build](https://github.com/mxenabled/widget-post-message-definitions/runs/7772021242) we ran before the cache was initialized, it took 1m57s, rerunning that same build after the cache was initialized and [we see that drop](https://github.com/mxenabled/widget-post-message-definitions/runs/7772098389) to 50s.