### PR TITLE
Dispatching events to delegate tests

### DIFF
--- a/packages/swift/Tests/DispatchingEventsToDelegateTests.swift
+++ b/packages/swift/Tests/DispatchingEventsToDelegateTests.swift
@@ -5,4 +5,75 @@ import Quick
 @testable import MXPostMessageDefinitions
 
 class DispatchingEventsToDelegateTests: QuickSpec {
+    override func spec() {
+        var delegate: ConnectWidgetEventDelegateMock!
+        var dispatcher: ConnectWidgetEventDispatcher!
+
+        beforeEach {
+            delegate = mock(ConnectWidgetEventDelegate.self)
+            dispatcher = ConnectWidgetEventDispatcher(delegate)
+        }
+
+        it("calls the generic widgetEvent handler") {
+            let payload = WidgetEvent.Load()
+            dispatcher.dispatch(url("load", payload))
+            verify(delegate.widgetEvent(any(WidgetEvent.Load.self))).wasCalled()
+        }
+
+        it("calls the specific widgetEvent handler") {
+            let payload = ConnectWidgetEvent.InstitutionSearch(userGuid: "USR-123",
+                                                               sessionGuid: "SES-123",
+                                                               query: "Epic")
+            dispatcher.dispatch(url("connect/institutionSearch", payload))
+            verify(delegate.widgetEvent(any(where: { $0 == payload }))).wasCalled()
+        }
+
+        it("is able to dispatch an event that includes an enum value") {
+            let payload = ConnectWidgetEvent.Loaded(userGuid: "USR-123",
+                                                    sessionGuid: "SES-123",
+                                                    initialStep: .search)
+            dispatcher.dispatch(url("connect/loaded", payload))
+            verify(delegate.widgetEvent(any(where: { $0 == payload }))).wasCalled()
+        }
+
+        it("is able to dispatch an event that includes a struct value") {
+            let payload = ConnectWidgetEvent.EnterCredentials(userGuid: "USR-123",
+                                                              sessionGuid: "SES-123",
+                                                              institution: ConnectEnterCredentialsInstitution(code: "i-code",
+                                                                                                              guid: "INS-123"))
+            dispatcher.dispatch(url("connect/enterCredentials", payload))
+            verify(delegate.widgetEvent(any(where: { $0 == payload }))).wasCalled()
+        }
+
+        it("is able to dispatch an event that includes an optional field") {
+            let payload = ConnectWidgetEvent.OAuthError(userGuid: "USR-123",
+                                                        sessionGuid: "SES-123",
+                                                        memberGuid: "MBR-123")
+            dispatcher.dispatch(url("connect/oauthError", payload))
+            verify(delegate.widgetEvent(any(where: { $0 == payload }))).wasCalled()
+        }
+
+        it("is able to dispatch an event that excludes an optional field") {
+            let payload = ConnectWidgetEvent.OAuthError(userGuid: "USR-123",
+                                                        sessionGuid: "SES-123")
+            dispatcher.dispatch(url("connect/oauthError", payload))
+            verify(delegate.widgetEvent(any(where: { $0 == payload }))).wasCalled()
+        }
+    }
+}
+
+func url<T: Encodable>(_ hostAndPath: String, _ metadata: T) -> URL {
+    return URL(string: "mx://\(hostAndPath)?metadata=\(encode(metadata))")!
+}
+
+func encode(_ string: String) -> String {
+    return string.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!
+}
+
+func encode<T: Encodable>(_ value: T) -> String {
+    let encoder = JSONEncoder()
+    encoder.keyEncodingStrategy = .convertToSnakeCase
+    let data = try! encoder.encode(value)
+    let string = String(data: data, encoding: .utf8)!
+    return string.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!
 }


### PR DESCRIPTION
Filling in the `DispatchingEventsToDelegateTests` test class with dispatching/parsing/delegate checks. I think I have the happy path covered. I'll add tests for error dispatching once that's implemented.