### PR TITLE
Swift: generic event handler signature update

### DIFF
--- a/lib/template/swift_source.rb
+++ b/lib/template/swift_source.rb
@@ -73,7 +73,7 @@ class Template::SwiftSource < Template::Base
     |/** Delegates **/
     |
     |public protocol <%= delegate_group_type_name(generic_post_message_definitions.sample) %> {
-    |    func widgetEvent(_ payload: Event)
+    |    func widgetEvent(_ url: URL)
     |<%- generic_post_message_definitions.each do |post_message| -%>
     |    func widgetEvent(_ payload: <%= event_group_type_name(post_message) %>.<%= payload_type_name(post_message) %>)
     |<%- end -%>
@@ -85,7 +85,7 @@ class Template::SwiftSource < Template::Base
     |}
     |
     |public extension <%= delegate_group_type_name(generic_post_message_definitions.sample) %> {
-    |    func widgetEvent(_: Event) {}
+    |    func widgetEvent(_: URL) {}
     |<%- generic_post_message_definitions.each do |post_message| -%>
     |    func widgetEvent(_: <%= event_group_type_name(post_message) %>.<%= payload_type_name(post_message) %>) {}
     |<%- end -%>
@@ -137,11 +137,11 @@ class Template::SwiftSource < Template::Base
     |    }
     |
     |    func dispatch(_ url: URL) {
+    |        delegate.widgetEvent(url)
+    |
     |        guard let event = parse(url) else {
     |            return
     |        }
-    |
-    |        delegate.widgetEvent(event)
     |
     |        switch event {
     |        <%- with_generic_post_messages(subgroup, post_messages).each do |post_message| -%>

--- a/packages/swift/Sources/Generated.swift
+++ b/packages/swift/Sources/Generated.swift
@@ -287,7 +287,7 @@ public struct ConnectUpdateCredentialsInstitution: Codable {
 /** Delegates **/
 
 public protocol WidgetEventDelegate {
-    func widgetEvent(_ payload: Event)
+    func widgetEvent(_ url: URL)
     func widgetEvent(_ payload: WidgetEvent.Load)
     func widgetEvent(_ payload: WidgetEvent.Ping)
     func widgetEvent(_ payload: WidgetEvent.Navigation)
@@ -295,7 +295,7 @@ public protocol WidgetEventDelegate {
 }
 
 public extension WidgetEventDelegate {
-    func widgetEvent(_: Event) {}
+    func widgetEvent(_: URL) {}
     func widgetEvent(_: WidgetEvent.Load) {}
     func widgetEvent(_: WidgetEvent.Ping) {}
     func widgetEvent(_: WidgetEvent.Navigation) {}
@@ -372,11 +372,11 @@ class WidgetEventDispatcher: Dispatcher {
     }
 
     func dispatch(_ url: URL) {
+        delegate.widgetEvent(url)
+
         guard let event = parse(url) else {
             return
         }
-
-        delegate.widgetEvent(event)
 
         switch event {
         case let event as WidgetEvent.Load:
@@ -420,11 +420,11 @@ class ConnectWidgetEventDispatcher: Dispatcher {
     }
 
     func dispatch(_ url: URL) {
+        delegate.widgetEvent(url)
+
         guard let event = parse(url) else {
             return
         }
-
-        delegate.widgetEvent(event)
 
         switch event {
         case let event as WidgetEvent.Load:
@@ -524,11 +524,11 @@ class PulseWidgetEventDispatcher: Dispatcher {
     }
 
     func dispatch(_ url: URL) {
+        delegate.widgetEvent(url)
+
         guard let event = parse(url) else {
             return
         }
-
-        delegate.widgetEvent(event)
 
         switch event {
         case let event as WidgetEvent.Load:

--- a/packages/swift/Tests/DispatchingEventsToDelegateTests.swift
+++ b/packages/swift/Tests/DispatchingEventsToDelegateTests.swift
@@ -98,10 +98,6 @@ func url<T: Encodable>(_ hostAndPath: String, _ metadata: T) -> URL {
     return URL(string: "mx://\(hostAndPath)?metadata=\(encode(metadata))")!
 }
 
-func encode(_ string: String) -> String {
-    return string.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!
-}
-
 func encode<T: Encodable>(_ value: T) -> String {
     let encoder = JSONEncoder()
     encoder.keyEncodingStrategy = .convertToSnakeCase

--- a/packages/swift/Tests/DispatchingEventsToDelegateTests.swift
+++ b/packages/swift/Tests/DispatchingEventsToDelegateTests.swift
@@ -14,10 +14,25 @@ class DispatchingEventsToDelegateTests: QuickSpec {
             dispatcher = ConnectWidgetEventDispatcher(delegate)
         }
 
-        it("calls the generic widgetEvent handler") {
-            let payload = WidgetEvent.Load()
-            dispatcher.dispatch(url("load", payload))
-            verify(delegate.widgetEvent(any(WidgetEvent.Load.self))).wasCalled()
+        describe("Generic widgetEvent handler") {
+            context("when the post message event is valid") {
+                it("calls the generic widgetEvent handler and the event specific handler") {
+                    let payload = ConnectWidgetEvent.InstitutionSearch(userGuid: "USR-123",
+                                                                       sessionGuid: "SES-123",
+                                                                       query: "Epic")
+                    dispatcher.dispatch(url("connect/institutionSearch", payload))
+                    verify(delegate.widgetEvent(URL(string: "mx://connect/institutionSearch?metadata=\(encode(payload))")!)).wasCalled()
+                    verify(delegate.widgetEvent(any(ConnectWidgetEvent.InstitutionSearch.self))).wasCalled()
+                }
+            }
+
+            context("when the post message event is invalid and cannot be parsed") {
+                it("calls the generic widgetEvent handler but not the event specific handler") {
+                    dispatcher.dispatch(url("connect/institutionSearch", "badbadbad"))
+                    verify(delegate.widgetEvent(URL(string: "mx://connect/institutionSearch?metadata=%22badbadbad%22")!)).wasCalled()
+                    verify(delegate.widgetEvent(any(ConnectWidgetEvent.InstitutionSearch.self))).wasNeverCalled()
+                }
+            }
         }
 
         it("calls the specific widgetEvent handler") {

--- a/packages/swift/Tests/DispatchingEventsToDelegateTests.swift
+++ b/packages/swift/Tests/DispatchingEventsToDelegateTests.swift
@@ -28,8 +28,8 @@ class DispatchingEventsToDelegateTests: QuickSpec {
 
             context("when the post message event is invalid and cannot be parsed") {
                 it("calls the generic widgetEvent handler but not the event specific handler") {
-                    dispatcher.dispatch(url("connect/institutionSearch", "badbadbad"))
-                    verify(delegate.widgetEvent(URL(string: "mx://connect/institutionSearch?metadata=%22badbadbad%22")!)).wasCalled()
+                    dispatcher.dispatch(url("connect/institutionSearch", "badToTheBone"))
+                    verify(delegate.widgetEvent(URL(string: "mx://connect/institutionSearch?metadata=%22badToTheBone%22")!)).wasCalled()
                     verify(delegate.widgetEvent(any(ConnectWidgetEvent.InstitutionSearch.self))).wasNeverCalled()
                 }
             }

--- a/packages/swift/Tests/Generated/Mocks.swift
+++ b/packages/swift/Tests/Generated/Mocks.swift
@@ -402,33 +402,6 @@ public final class ConnectWidgetEventDelegateMock: MXPostMessageDefinitions.Conn
     return Mockingbird.Mockable<Mockingbird.FunctionDeclaration, (MXPostMessageDefinitions.ConnectWidgetEvent.UpdateCredentials) -> Void, Void>(mock: self, invocation: Mockingbird.SwiftInvocation(selectorName: "`widgetEvent`(_ `payload`: MXPostMessageDefinitions.ConnectWidgetEvent.UpdateCredentials) -> Void", selectorType: Mockingbird.SelectorType.method, arguments: [Mockingbird.resolve(`payload`)], returnType: Swift.ObjectIdentifier((Void).self)))
   }
 
-  // MARK: Mocked `widgetEvent`(_ `payload`: MXPostMessageDefinitions.Event)
-  public func `widgetEvent`(_ `payload`: MXPostMessageDefinitions.Event) -> Void {
-    return self.mockingbirdContext.mocking.didInvoke(Mockingbird.SwiftInvocation(selectorName: "`widgetEvent`(_ `payload`: MXPostMessageDefinitions.Event) -> Void", selectorType: Mockingbird.SelectorType.method, arguments: [Mockingbird.ArgumentMatcher(`payload`)], returnType: Swift.ObjectIdentifier((Void).self))) {
-      self.mockingbirdContext.recordInvocation($0)
-      let mkbImpl = self.mockingbirdContext.stubbing.implementation(for: $0)
-      if let mkbImpl = mkbImpl as? (MXPostMessageDefinitions.Event) -> Void { return mkbImpl(`payload`) }
-      if let mkbImpl = mkbImpl as? () -> Void { return mkbImpl() }
-      for mkbTargetBox in self.mockingbirdContext.proxy.targets(for: $0) {
-        switch mkbTargetBox.target {
-        case .super:
-          break
-        case .object(let mkbObject):
-          guard var mkbObject = mkbObject as? MockingbirdSupertype else { break }
-          let mkbValue: Void = mkbObject.`widgetEvent`(`payload`)
-          self.mockingbirdContext.proxy.updateTarget(&mkbObject, in: mkbTargetBox)
-          return mkbValue
-        }
-      }
-      if let mkbValue = self.mockingbirdContext.stubbing.defaultValueProvider.value.provideValue(for: (Void).self) { return mkbValue }
-      self.mockingbirdContext.stubbing.failTest(for: $0, at: self.mockingbirdContext.sourceLocation)
-    }
-  }
-
-  public func `widgetEvent`(_ `payload`: @autoclosure () -> MXPostMessageDefinitions.Event) -> Mockingbird.Mockable<Mockingbird.FunctionDeclaration, (MXPostMessageDefinitions.Event) -> Void, Void> {
-    return Mockingbird.Mockable<Mockingbird.FunctionDeclaration, (MXPostMessageDefinitions.Event) -> Void, Void>(mock: self, invocation: Mockingbird.SwiftInvocation(selectorName: "`widgetEvent`(_ `payload`: MXPostMessageDefinitions.Event) -> Void", selectorType: Mockingbird.SelectorType.method, arguments: [Mockingbird.resolve(`payload`)], returnType: Swift.ObjectIdentifier((Void).self)))
-  }
-
   // MARK: Mocked `widgetEvent`(_ `payload`: MXPostMessageDefinitions.WidgetEvent.FocusTrap)
   public func `widgetEvent`(_ `payload`: MXPostMessageDefinitions.WidgetEvent.FocusTrap) -> Void {
     return self.mockingbirdContext.mocking.didInvoke(Mockingbird.SwiftInvocation(selectorName: "`widgetEvent`(_ `payload`: MXPostMessageDefinitions.WidgetEvent.FocusTrap) -> Void", selectorType: Mockingbird.SelectorType.method, arguments: [Mockingbird.ArgumentMatcher(`payload`)], returnType: Swift.ObjectIdentifier((Void).self))) {
@@ -536,6 +509,33 @@ public final class ConnectWidgetEventDelegateMock: MXPostMessageDefinitions.Conn
   public func `widgetEvent`(_ `payload`: @autoclosure () -> MXPostMessageDefinitions.WidgetEvent.Ping) -> Mockingbird.Mockable<Mockingbird.FunctionDeclaration, (MXPostMessageDefinitions.WidgetEvent.Ping) -> Void, Void> {
     return Mockingbird.Mockable<Mockingbird.FunctionDeclaration, (MXPostMessageDefinitions.WidgetEvent.Ping) -> Void, Void>(mock: self, invocation: Mockingbird.SwiftInvocation(selectorName: "`widgetEvent`(_ `payload`: MXPostMessageDefinitions.WidgetEvent.Ping) -> Void", selectorType: Mockingbird.SelectorType.method, arguments: [Mockingbird.resolve(`payload`)], returnType: Swift.ObjectIdentifier((Void).self)))
   }
+
+  // MARK: Mocked `widgetEvent`(_ `url`: URL)
+  public func `widgetEvent`(_ `url`: URL) -> Void {
+    return self.mockingbirdContext.mocking.didInvoke(Mockingbird.SwiftInvocation(selectorName: "`widgetEvent`(_ `url`: URL) -> Void", selectorType: Mockingbird.SelectorType.method, arguments: [Mockingbird.ArgumentMatcher(`url`)], returnType: Swift.ObjectIdentifier((Void).self))) {
+      self.mockingbirdContext.recordInvocation($0)
+      let mkbImpl = self.mockingbirdContext.stubbing.implementation(for: $0)
+      if let mkbImpl = mkbImpl as? (URL) -> Void { return mkbImpl(`url`) }
+      if let mkbImpl = mkbImpl as? () -> Void { return mkbImpl() }
+      for mkbTargetBox in self.mockingbirdContext.proxy.targets(for: $0) {
+        switch mkbTargetBox.target {
+        case .super:
+          break
+        case .object(let mkbObject):
+          guard var mkbObject = mkbObject as? MockingbirdSupertype else { break }
+          let mkbValue: Void = mkbObject.`widgetEvent`(`url`)
+          self.mockingbirdContext.proxy.updateTarget(&mkbObject, in: mkbTargetBox)
+          return mkbValue
+        }
+      }
+      if let mkbValue = self.mockingbirdContext.stubbing.defaultValueProvider.value.provideValue(for: (Void).self) { return mkbValue }
+      self.mockingbirdContext.stubbing.failTest(for: $0, at: self.mockingbirdContext.sourceLocation)
+    }
+  }
+
+  public func `widgetEvent`(_ `url`: @autoclosure () -> URL) -> Mockingbird.Mockable<Mockingbird.FunctionDeclaration, (URL) -> Void, Void> {
+    return Mockingbird.Mockable<Mockingbird.FunctionDeclaration, (URL) -> Void, Void>(mock: self, invocation: Mockingbird.SwiftInvocation(selectorName: "`widgetEvent`(_ `url`: URL) -> Void", selectorType: Mockingbird.SelectorType.method, arguments: [Mockingbird.resolve(`url`)], returnType: Swift.ObjectIdentifier((Void).self)))
+  }
 }
 
 /// Returns a concrete mock of `ConnectWidgetEventDelegate`.
@@ -552,33 +552,6 @@ public final class PulseWidgetEventDelegateMock: MXPostMessageDefinitions.PulseW
   fileprivate init(sourceLocation: Mockingbird.SourceLocation) {
     self.mockingbirdContext.sourceLocation = sourceLocation
     PulseWidgetEventDelegateMock.staticMock.mockingbirdContext.sourceLocation = sourceLocation
-  }
-
-  // MARK: Mocked `widgetEvent`(_ `payload`: MXPostMessageDefinitions.Event)
-  public func `widgetEvent`(_ `payload`: MXPostMessageDefinitions.Event) -> Void {
-    return self.mockingbirdContext.mocking.didInvoke(Mockingbird.SwiftInvocation(selectorName: "`widgetEvent`(_ `payload`: MXPostMessageDefinitions.Event) -> Void", selectorType: Mockingbird.SelectorType.method, arguments: [Mockingbird.ArgumentMatcher(`payload`)], returnType: Swift.ObjectIdentifier((Void).self))) {
-      self.mockingbirdContext.recordInvocation($0)
-      let mkbImpl = self.mockingbirdContext.stubbing.implementation(for: $0)
-      if let mkbImpl = mkbImpl as? (MXPostMessageDefinitions.Event) -> Void { return mkbImpl(`payload`) }
-      if let mkbImpl = mkbImpl as? () -> Void { return mkbImpl() }
-      for mkbTargetBox in self.mockingbirdContext.proxy.targets(for: $0) {
-        switch mkbTargetBox.target {
-        case .super:
-          break
-        case .object(let mkbObject):
-          guard var mkbObject = mkbObject as? MockingbirdSupertype else { break }
-          let mkbValue: Void = mkbObject.`widgetEvent`(`payload`)
-          self.mockingbirdContext.proxy.updateTarget(&mkbObject, in: mkbTargetBox)
-          return mkbValue
-        }
-      }
-      if let mkbValue = self.mockingbirdContext.stubbing.defaultValueProvider.value.provideValue(for: (Void).self) { return mkbValue }
-      self.mockingbirdContext.stubbing.failTest(for: $0, at: self.mockingbirdContext.sourceLocation)
-    }
-  }
-
-  public func `widgetEvent`(_ `payload`: @autoclosure () -> MXPostMessageDefinitions.Event) -> Mockingbird.Mockable<Mockingbird.FunctionDeclaration, (MXPostMessageDefinitions.Event) -> Void, Void> {
-    return Mockingbird.Mockable<Mockingbird.FunctionDeclaration, (MXPostMessageDefinitions.Event) -> Void, Void>(mock: self, invocation: Mockingbird.SwiftInvocation(selectorName: "`widgetEvent`(_ `payload`: MXPostMessageDefinitions.Event) -> Void", selectorType: Mockingbird.SelectorType.method, arguments: [Mockingbird.resolve(`payload`)], returnType: Swift.ObjectIdentifier((Void).self)))
   }
 
   // MARK: Mocked `widgetEvent`(_ `payload`: MXPostMessageDefinitions.PulseWidgetEvent.OverdraftWarningCtaTransferFunds)
@@ -714,6 +687,33 @@ public final class PulseWidgetEventDelegateMock: MXPostMessageDefinitions.PulseW
 
   public func `widgetEvent`(_ `payload`: @autoclosure () -> MXPostMessageDefinitions.WidgetEvent.Ping) -> Mockingbird.Mockable<Mockingbird.FunctionDeclaration, (MXPostMessageDefinitions.WidgetEvent.Ping) -> Void, Void> {
     return Mockingbird.Mockable<Mockingbird.FunctionDeclaration, (MXPostMessageDefinitions.WidgetEvent.Ping) -> Void, Void>(mock: self, invocation: Mockingbird.SwiftInvocation(selectorName: "`widgetEvent`(_ `payload`: MXPostMessageDefinitions.WidgetEvent.Ping) -> Void", selectorType: Mockingbird.SelectorType.method, arguments: [Mockingbird.resolve(`payload`)], returnType: Swift.ObjectIdentifier((Void).self)))
+  }
+
+  // MARK: Mocked `widgetEvent`(_ `url`: URL)
+  public func `widgetEvent`(_ `url`: URL) -> Void {
+    return self.mockingbirdContext.mocking.didInvoke(Mockingbird.SwiftInvocation(selectorName: "`widgetEvent`(_ `url`: URL) -> Void", selectorType: Mockingbird.SelectorType.method, arguments: [Mockingbird.ArgumentMatcher(`url`)], returnType: Swift.ObjectIdentifier((Void).self))) {
+      self.mockingbirdContext.recordInvocation($0)
+      let mkbImpl = self.mockingbirdContext.stubbing.implementation(for: $0)
+      if let mkbImpl = mkbImpl as? (URL) -> Void { return mkbImpl(`url`) }
+      if let mkbImpl = mkbImpl as? () -> Void { return mkbImpl() }
+      for mkbTargetBox in self.mockingbirdContext.proxy.targets(for: $0) {
+        switch mkbTargetBox.target {
+        case .super:
+          break
+        case .object(let mkbObject):
+          guard var mkbObject = mkbObject as? MockingbirdSupertype else { break }
+          let mkbValue: Void = mkbObject.`widgetEvent`(`url`)
+          self.mockingbirdContext.proxy.updateTarget(&mkbObject, in: mkbTargetBox)
+          return mkbValue
+        }
+      }
+      if let mkbValue = self.mockingbirdContext.stubbing.defaultValueProvider.value.provideValue(for: (Void).self) { return mkbValue }
+      self.mockingbirdContext.stubbing.failTest(for: $0, at: self.mockingbirdContext.sourceLocation)
+    }
+  }
+
+  public func `widgetEvent`(_ `url`: @autoclosure () -> URL) -> Mockingbird.Mockable<Mockingbird.FunctionDeclaration, (URL) -> Void, Void> {
+    return Mockingbird.Mockable<Mockingbird.FunctionDeclaration, (URL) -> Void, Void>(mock: self, invocation: Mockingbird.SwiftInvocation(selectorName: "`widgetEvent`(_ `url`: URL) -> Void", selectorType: Mockingbird.SelectorType.method, arguments: [Mockingbird.resolve(`url`)], returnType: Swift.ObjectIdentifier((Void).self)))
   }
 }
 


### PR DESCRIPTION
The generic event handler should take a `URL` instead of an `Event`. We may not always be able to generate an `Event`, but we _always_ want to call the generic handler. So we need to change this to the raw-most value that we know we'll always have, and that's the URL itself in the case of the iOS/Swift code.

This is the pattern we follow in other implementations where the original value is either a [string URL](https://github.com/mxenabled/widget-post-message-definitions/blob/60ff61b6e10742a32ec3d7b76005cf19c378b9de/packages/typescript/src/generated.ts#L634) or a [post message object](https://github.com/mxenabled/widget-post-message-definitions/blob/60ff61b6e10742a32ec3d7b76005cf19c378b9de/packages/typescript/src/generated.ts#L649).