### PR TITLE
Swift: error handler

### DIFF
--- a/lib/template/swift_source.rb
+++ b/lib/template/swift_source.rb
@@ -7,6 +7,10 @@ class Template::SwiftSource < Template::Base
     |
     |public protocol Event: Codable {}
     |
+    |public enum EventError: Error, Equatable {
+    |    case invalidEventURL(url: URL)
+    |}
+    |
     |/** Payloads **/
     |<% post_message_definitions_by_subgroup.each do |subgroup, post_message_definitions| %>
     |public enum <%= event_group_type_name(post_message_definitions.first) %> {
@@ -74,6 +78,7 @@ class Template::SwiftSource < Template::Base
     |
     |public protocol <%= delegate_group_type_name(generic_post_message_definitions.sample) %> {
     |    func widgetEvent(_ url: URL)
+    |    func widgetEvent(_ error: EventError)
     |<%- generic_post_message_definitions.each do |post_message| -%>
     |    func widgetEvent(_ payload: <%= event_group_type_name(post_message) %>.<%= payload_type_name(post_message) %>)
     |<%- end -%>
@@ -86,6 +91,7 @@ class Template::SwiftSource < Template::Base
     |
     |public extension <%= delegate_group_type_name(generic_post_message_definitions.sample) %> {
     |    func widgetEvent(_: URL) {}
+    |    func widgetEvent(_: EventError) {}
     |<%- generic_post_message_definitions.each do |post_message| -%>
     |    func widgetEvent(_: <%= event_group_type_name(post_message) %>.<%= payload_type_name(post_message) %>) {}
     |<%- end -%>
@@ -140,6 +146,7 @@ class Template::SwiftSource < Template::Base
     |        delegate.widgetEvent(url)
     |
     |        guard let event = parse(url) else {
+    |            delegate.widgetEvent(.invalidEventURL(url: url))
     |            return
     |        }
     |
@@ -149,6 +156,7 @@ class Template::SwiftSource < Template::Base
     |            delegate.widgetEvent(event)
     |        <%- end -%>
     |        default:
+    |            // Unreachable
     |            return
     |        }
     |    }

--- a/packages/swift/Sources/Generated.swift
+++ b/packages/swift/Sources/Generated.swift
@@ -11,6 +11,10 @@ import Foundation
 
 public protocol Event: Codable {}
 
+public enum EventError: Error, Equatable {
+    case invalidEventURL(url: URL)
+}
+
 /** Payloads **/
 
 public enum WidgetEvent {
@@ -288,6 +292,7 @@ public struct ConnectUpdateCredentialsInstitution: Codable {
 
 public protocol WidgetEventDelegate {
     func widgetEvent(_ url: URL)
+    func widgetEvent(_ error: EventError)
     func widgetEvent(_ payload: WidgetEvent.Load)
     func widgetEvent(_ payload: WidgetEvent.Ping)
     func widgetEvent(_ payload: WidgetEvent.Navigation)
@@ -296,6 +301,7 @@ public protocol WidgetEventDelegate {
 
 public extension WidgetEventDelegate {
     func widgetEvent(_: URL) {}
+    func widgetEvent(_: EventError) {}
     func widgetEvent(_: WidgetEvent.Load) {}
     func widgetEvent(_: WidgetEvent.Ping) {}
     func widgetEvent(_: WidgetEvent.Navigation) {}
@@ -375,6 +381,7 @@ class WidgetEventDispatcher: Dispatcher {
         delegate.widgetEvent(url)
 
         guard let event = parse(url) else {
+            delegate.widgetEvent(.invalidEventURL(url: url))
             return
         }
 
@@ -388,6 +395,7 @@ class WidgetEventDispatcher: Dispatcher {
         case let event as WidgetEvent.FocusTrap:
             delegate.widgetEvent(event)
         default:
+            // Unreachable
             return
         }
     }
@@ -423,6 +431,7 @@ class ConnectWidgetEventDispatcher: Dispatcher {
         delegate.widgetEvent(url)
 
         guard let event = parse(url) else {
+            delegate.widgetEvent(.invalidEventURL(url: url))
             return
         }
 
@@ -464,6 +473,7 @@ class ConnectWidgetEventDispatcher: Dispatcher {
         case let event as ConnectWidgetEvent.UpdateCredentials:
             delegate.widgetEvent(event)
         default:
+            // Unreachable
             return
         }
     }
@@ -527,6 +537,7 @@ class PulseWidgetEventDispatcher: Dispatcher {
         delegate.widgetEvent(url)
 
         guard let event = parse(url) else {
+            delegate.widgetEvent(.invalidEventURL(url: url))
             return
         }
 
@@ -542,6 +553,7 @@ class PulseWidgetEventDispatcher: Dispatcher {
         case let event as PulseWidgetEvent.OverdraftWarningCtaTransferFunds:
             delegate.widgetEvent(event)
         default:
+            // Unreachable
             return
         }
     }

--- a/packages/swift/Tests/DispatchingEventsToDelegateTests.swift
+++ b/packages/swift/Tests/DispatchingEventsToDelegateTests.swift
@@ -35,6 +35,13 @@ class DispatchingEventsToDelegateTests: QuickSpec {
             }
         }
 
+        describe("Error widgetEvent handler") {
+            it("calls the error handler when unable to parse the event URL") {
+                dispatcher.dispatch(url("bad", "toTheBone"))
+                verify(delegate.widgetEvent(.invalidEventURL(url: URL(string: "mx://bad?metadata=%22toTheBone%22")!))).wasCalled()
+            }
+        }
+
         it("calls the specific widgetEvent handler") {
             let payload = ConnectWidgetEvent.InstitutionSearch(userGuid: "USR-123",
                                                                sessionGuid: "SES-123",

--- a/packages/swift/Tests/Generated/Mocks.swift
+++ b/packages/swift/Tests/Generated/Mocks.swift
@@ -402,6 +402,33 @@ public final class ConnectWidgetEventDelegateMock: MXPostMessageDefinitions.Conn
     return Mockingbird.Mockable<Mockingbird.FunctionDeclaration, (MXPostMessageDefinitions.ConnectWidgetEvent.UpdateCredentials) -> Void, Void>(mock: self, invocation: Mockingbird.SwiftInvocation(selectorName: "`widgetEvent`(_ `payload`: MXPostMessageDefinitions.ConnectWidgetEvent.UpdateCredentials) -> Void", selectorType: Mockingbird.SelectorType.method, arguments: [Mockingbird.resolve(`payload`)], returnType: Swift.ObjectIdentifier((Void).self)))
   }
 
+  // MARK: Mocked `widgetEvent`(_ `error`: MXPostMessageDefinitions.EventError)
+  public func `widgetEvent`(_ `error`: MXPostMessageDefinitions.EventError) -> Void {
+    return self.mockingbirdContext.mocking.didInvoke(Mockingbird.SwiftInvocation(selectorName: "`widgetEvent`(_ `error`: MXPostMessageDefinitions.EventError) -> Void", selectorType: Mockingbird.SelectorType.method, arguments: [Mockingbird.ArgumentMatcher(`error`)], returnType: Swift.ObjectIdentifier((Void).self))) {
+      self.mockingbirdContext.recordInvocation($0)
+      let mkbImpl = self.mockingbirdContext.stubbing.implementation(for: $0)
+      if let mkbImpl = mkbImpl as? (MXPostMessageDefinitions.EventError) -> Void { return mkbImpl(`error`) }
+      if let mkbImpl = mkbImpl as? () -> Void { return mkbImpl() }
+      for mkbTargetBox in self.mockingbirdContext.proxy.targets(for: $0) {
+        switch mkbTargetBox.target {
+        case .super:
+          break
+        case .object(let mkbObject):
+          guard var mkbObject = mkbObject as? MockingbirdSupertype else { break }
+          let mkbValue: Void = mkbObject.`widgetEvent`(`error`)
+          self.mockingbirdContext.proxy.updateTarget(&mkbObject, in: mkbTargetBox)
+          return mkbValue
+        }
+      }
+      if let mkbValue = self.mockingbirdContext.stubbing.defaultValueProvider.value.provideValue(for: (Void).self) { return mkbValue }
+      self.mockingbirdContext.stubbing.failTest(for: $0, at: self.mockingbirdContext.sourceLocation)
+    }
+  }
+
+  public func `widgetEvent`(_ `error`: @autoclosure () -> MXPostMessageDefinitions.EventError) -> Mockingbird.Mockable<Mockingbird.FunctionDeclaration, (MXPostMessageDefinitions.EventError) -> Void, Void> {
+    return Mockingbird.Mockable<Mockingbird.FunctionDeclaration, (MXPostMessageDefinitions.EventError) -> Void, Void>(mock: self, invocation: Mockingbird.SwiftInvocation(selectorName: "`widgetEvent`(_ `error`: MXPostMessageDefinitions.EventError) -> Void", selectorType: Mockingbird.SelectorType.method, arguments: [Mockingbird.resolve(`error`)], returnType: Swift.ObjectIdentifier((Void).self)))
+  }
+
   // MARK: Mocked `widgetEvent`(_ `payload`: MXPostMessageDefinitions.WidgetEvent.FocusTrap)
   public func `widgetEvent`(_ `payload`: MXPostMessageDefinitions.WidgetEvent.FocusTrap) -> Void {
     return self.mockingbirdContext.mocking.didInvoke(Mockingbird.SwiftInvocation(selectorName: "`widgetEvent`(_ `payload`: MXPostMessageDefinitions.WidgetEvent.FocusTrap) -> Void", selectorType: Mockingbird.SelectorType.method, arguments: [Mockingbird.ArgumentMatcher(`payload`)], returnType: Swift.ObjectIdentifier((Void).self))) {
@@ -552,6 +579,33 @@ public final class PulseWidgetEventDelegateMock: MXPostMessageDefinitions.PulseW
   fileprivate init(sourceLocation: Mockingbird.SourceLocation) {
     self.mockingbirdContext.sourceLocation = sourceLocation
     PulseWidgetEventDelegateMock.staticMock.mockingbirdContext.sourceLocation = sourceLocation
+  }
+
+  // MARK: Mocked `widgetEvent`(_ `error`: MXPostMessageDefinitions.EventError)
+  public func `widgetEvent`(_ `error`: MXPostMessageDefinitions.EventError) -> Void {
+    return self.mockingbirdContext.mocking.didInvoke(Mockingbird.SwiftInvocation(selectorName: "`widgetEvent`(_ `error`: MXPostMessageDefinitions.EventError) -> Void", selectorType: Mockingbird.SelectorType.method, arguments: [Mockingbird.ArgumentMatcher(`error`)], returnType: Swift.ObjectIdentifier((Void).self))) {
+      self.mockingbirdContext.recordInvocation($0)
+      let mkbImpl = self.mockingbirdContext.stubbing.implementation(for: $0)
+      if let mkbImpl = mkbImpl as? (MXPostMessageDefinitions.EventError) -> Void { return mkbImpl(`error`) }
+      if let mkbImpl = mkbImpl as? () -> Void { return mkbImpl() }
+      for mkbTargetBox in self.mockingbirdContext.proxy.targets(for: $0) {
+        switch mkbTargetBox.target {
+        case .super:
+          break
+        case .object(let mkbObject):
+          guard var mkbObject = mkbObject as? MockingbirdSupertype else { break }
+          let mkbValue: Void = mkbObject.`widgetEvent`(`error`)
+          self.mockingbirdContext.proxy.updateTarget(&mkbObject, in: mkbTargetBox)
+          return mkbValue
+        }
+      }
+      if let mkbValue = self.mockingbirdContext.stubbing.defaultValueProvider.value.provideValue(for: (Void).self) { return mkbValue }
+      self.mockingbirdContext.stubbing.failTest(for: $0, at: self.mockingbirdContext.sourceLocation)
+    }
+  }
+
+  public func `widgetEvent`(_ `error`: @autoclosure () -> MXPostMessageDefinitions.EventError) -> Mockingbird.Mockable<Mockingbird.FunctionDeclaration, (MXPostMessageDefinitions.EventError) -> Void, Void> {
+    return Mockingbird.Mockable<Mockingbird.FunctionDeclaration, (MXPostMessageDefinitions.EventError) -> Void, Void>(mock: self, invocation: Mockingbird.SwiftInvocation(selectorName: "`widgetEvent`(_ `error`: MXPostMessageDefinitions.EventError) -> Void", selectorType: Mockingbird.SelectorType.method, arguments: [Mockingbird.resolve(`error`)], returnType: Swift.ObjectIdentifier((Void).self)))
   }
 
   // MARK: Mocked `widgetEvent`(_ `payload`: MXPostMessageDefinitions.PulseWidgetEvent.OverdraftWarningCtaTransferFunds)


### PR DESCRIPTION
Calling `widgetEvent(_ error: EventError)` when we can't parse an event URL.