### PR TITLE
Add backToSearch postmessage support

### DIFF
--- a/lib/post_message_definition.yml
+++ b/lib/post_message_definition.yml
@@ -122,6 +122,10 @@ post_messages:
             type:
               code: string
               guid: string
+      backToSearch:
+        payload:
+          <<: *user_session_properties
+          context: string
     pulse:
       overdraftWarning/cta/transferFunds:
         payload:

--- a/packages/swift/Sources/Generated.swift
+++ b/packages/swift/Sources/Generated.swift
@@ -234,6 +234,17 @@ public enum ConnectWidgetEvent {
                 && lhs.institution == rhs.institution
         }
     }
+    public struct BackToSearch: Event {
+        public var userGuid: String
+        public var sessionGuid: String
+        public var context: String
+
+        public static func == (lhs: ConnectWidgetEvent.BackToSearch, rhs: ConnectWidgetEvent.BackToSearch) -> Bool {
+            return lhs.userGuid == rhs.userGuid
+                && lhs.sessionGuid == rhs.sessionGuid
+                && lhs.context == rhs.context
+        }
+    }
 }
 
 public enum PulseWidgetEvent {
@@ -314,6 +325,7 @@ public protocol ConnectWidgetEventDelegate: WidgetEventDelegate {
     func widgetEvent(_ payload: ConnectWidgetEvent.StepChange)
     func widgetEvent(_ payload: ConnectWidgetEvent.SubmitMFA)
     func widgetEvent(_ payload: ConnectWidgetEvent.UpdateCredentials)
+    func widgetEvent(_ payload: ConnectWidgetEvent.BackToSearch)
 }
 
 public extension ConnectWidgetEventDelegate {
@@ -331,6 +343,7 @@ public extension ConnectWidgetEventDelegate {
     func widgetEvent(_: ConnectWidgetEvent.StepChange) {}
     func widgetEvent(_: ConnectWidgetEvent.SubmitMFA) {}
     func widgetEvent(_: ConnectWidgetEvent.UpdateCredentials) {}
+    func widgetEvent(_: ConnectWidgetEvent.BackToSearch) {}
 }
 
 public protocol PulseWidgetEventDelegate: WidgetEventDelegate {
@@ -465,6 +478,8 @@ class ConnectWidgetEventDispatcher: Dispatcher {
             delegate.widgetEvent(event)
         case let event as ConnectWidgetEvent.UpdateCredentials:
             delegate.widgetEvent(event)
+        case let event as ConnectWidgetEvent.BackToSearch:
+            delegate.widgetEvent(event)
         default:
             // Unreachable
             return nil
@@ -515,6 +530,8 @@ class ConnectWidgetEventDispatcher: Dispatcher {
             return try? decode(ConnectWidgetEvent.SubmitMFA.self, metadata)
         case ("connect", "/updateCredentials"):
             return try? decode(ConnectWidgetEvent.UpdateCredentials.self, metadata)
+        case ("connect", "/backToSearch"):
+            return try? decode(ConnectWidgetEvent.BackToSearch.self, metadata)
         default:
             return .none
         }

--- a/packages/typescript/docs/react-native-sdk-generated.md
+++ b/packages/typescript/docs/react-native-sdk-generated.md
@@ -436,3 +436,31 @@ import { ConnectWidget } from "@mxenabled/react-native-widget-sdk"
 
 </details>
 
+---
+### Back to search (`mx/connect/backToSearch`)
+
+- Widget callback prop name: `onBackToSearch`
+- Payload fields:
+    - `user_guid` (`string`)
+    - `session_guid` (`string`)
+    - `context` (`string`)
+
+<details>
+<summary>Click here to view a sample usage of <code>onBackToSearch</code>.</summary>
+
+```jsx
+import { ConnectWidget } from "@mxenabled/react-native-widget-sdk"
+
+<ConnectWidget
+  url="https://widgets.moneydesktop.com/md/connect/..."
+
+  onBackToSearch={(payload) => {
+    console.log(`User guid: ${payload.user_guid}`)
+    console.log(`Session guid: ${payload.session_guid}`)
+    console.log(`Context: ${payload.context}`)
+  }
+/>
+```
+
+</details>
+

--- a/packages/typescript/docs/web-sdk-generated.md
+++ b/packages/typescript/docs/web-sdk-generated.md
@@ -408,3 +408,29 @@ const widget = widgetSdk.ConnectWidget({
 
 </details>
 
+---
+### Back to search (`mx/connect/backToSearch`)
+
+- Widget callback prop name: `onBackToSearch`
+- Payload fields:
+    - `user_guid` (`string`)
+    - `session_guid` (`string`)
+    - `context` (`string`)
+
+<details>
+<summary>Click here to view a sample usage of <code>onBackToSearch</code>.</summary>
+
+```javascript
+const widget = widgetSdk.ConnectWidget({
+  url: "https://widgets.moneydesktop.com/md/connect/...",
+
+  onBackToSearch: (payload) => {
+    console.log(`User guid: ${payload.user_guid}`)
+    console.log(`Session guid: ${payload.session_guid}`)
+    console.log(`Context: ${payload.context}`)
+  }
+})
+```
+
+</details>
+

--- a/packages/typescript/package-lock.json
+++ b/packages/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mxenabled/widget-post-message-definitions",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mxenabled/widget-post-message-definitions",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^27.4.1",

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mxenabled/widget-post-message-definitions",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Widget Post Message Definitions for use in SDKs",
   "main": "dist/index.js",
   "license": "MIT",

--- a/packages/typescript/src/generated.ts
+++ b/packages/typescript/src/generated.ts
@@ -36,6 +36,7 @@ export enum Type {
   ConnectStepChange = "mx/connect/stepChange",
   ConnectSubmitMFA = "mx/connect/submitMFA",
   ConnectUpdateCredentials = "mx/connect/updateCredentials",
+  ConnectBackToSearch = "mx/connect/backToSearch",
   PulseOverdraftWarningCtaTransferFunds = "mx/pulse/overdraftWarning/cta/transferFunds",
   AccountCreated = "mx/account/created",
 }
@@ -75,6 +76,8 @@ const typeLookup: Record<string, Type> = {
   "mx/connect/submitmfa": Type.ConnectSubmitMFA, // cspell:disable-line
   [Type.ConnectUpdateCredentials]: Type.ConnectUpdateCredentials,
   "mx/connect/updatecredentials": Type.ConnectUpdateCredentials, // cspell:disable-line
+  [Type.ConnectBackToSearch]: Type.ConnectBackToSearch,
+  "mx/connect/backtosearch": Type.ConnectBackToSearch, // cspell:disable-line
   [Type.PulseOverdraftWarningCtaTransferFunds]: Type.PulseOverdraftWarningCtaTransferFunds,
   "mx/pulse/overdraftwarning/cta/transferfunds": Type.PulseOverdraftWarningCtaTransferFunds, // cspell:disable-line
   [Type.AccountCreated]: Type.AccountCreated,
@@ -214,6 +217,13 @@ export type ConnectUpdateCredentialsPayload = {
   institution: { code: string, guid: string },
 }
 
+export type ConnectBackToSearchPayload = {
+  type: Type.ConnectBackToSearch,
+  user_guid: string,
+  session_guid: string,
+  context: string,
+}
+
 export type PulseOverdraftWarningCtaTransferFundsPayload = {
   type: Type.PulseOverdraftWarningCtaTransferFunds,
   account_guid: string,
@@ -246,6 +256,7 @@ export type WidgetPayload =
   | ConnectStepChangePayload
   | ConnectSubmitMFAPayload
   | ConnectUpdateCredentialsPayload
+  | ConnectBackToSearchPayload
   | PulseOverdraftWarningCtaTransferFundsPayload
 
 export type EntityPayload =
@@ -495,6 +506,18 @@ function buildPayload(type: Type, metadata: Metadata): Payload {
         institution: metadata.institution as { code: string, guid: string },
       }
 
+    case Type.ConnectBackToSearch:
+      assertMessageProp(metadata, "mx/connect/backToSearch", "user_guid", "string")
+      assertMessageProp(metadata, "mx/connect/backToSearch", "session_guid", "string")
+      assertMessageProp(metadata, "mx/connect/backToSearch", "context", "string")
+
+      return {
+        type,
+        user_guid: metadata.user_guid as string,
+        session_guid: metadata.session_guid as string,
+        context: metadata.context as string,
+      }
+
     case Type.PulseOverdraftWarningCtaTransferFunds:
       assertMessageProp(metadata, "mx/pulse/overdraftWarning/cta/transferFunds", "account_guid", "string")
       assertMessageProp(metadata, "mx/pulse/overdraftWarning/cta/transferFunds", "amount", "number")
@@ -595,6 +618,7 @@ export type ConnectPostMessageCallbackProps<T> = WidgetPostMessageCallbackProps<
   onStepChange?: (payload: ConnectStepChangePayload) => void
   onSubmitMFA?: (payload: ConnectSubmitMFAPayload) => void
   onUpdateCredentials?: (payload: ConnectUpdateCredentialsPayload) => void
+  onBackToSearch?: (payload: ConnectBackToSearchPayload) => void
 }
 
 export type PulsePostMessageCallbackProps<T> = WidgetPostMessageCallbackProps<T> & {
@@ -808,6 +832,10 @@ function dispatchConnectInternalMessage<T>(payload: Payload, callbacks: ConnectP
 
     case Type.ConnectUpdateCredentials:
       callbacks.onUpdateCredentials?.(payload)
+      break
+
+    case Type.ConnectBackToSearch:
+      callbacks.onBackToSearch?.(payload)
       break
 
     default:


### PR DESCRIPTION
This PR adds the support of a new Connect postmessage: `backToSearch` with `context` as payload.

**Changes**

-  I updated `lib/post_message_definition.yml` to add new `backToSearch`  postmessage.
-  I run `./bin/run` to execute all generators

**Testing instructions** 

-  Checkout this branch and run `npm run build` in `widget-post-message-definitions/packages/typescript` folder
-  Update web-widget-sdk [package.json file](https://github.com/mxenabled/web-widget-sdk/blob/master/package.json#L61) to point to a local `widget-post-message-definitions` package, like so: `"@mxenabled/widget-post-message-definitions": "file:../widget-post-message-definitions/packages/typescript"` and run `npm install && npm ci && npm run build`.
- Update serenity [package.json file](https://gitlab.mx.com/mx/raja/-/merge_requests/8713/diffs#fa288d1472d29beccb489a676f68739ad365fc47_33_33) to point to a local `web-widget-sdk` package, like so: `"@mxenabled/web-widget-sdk": "file:../web-widget-sdk"` and run `npm install && npm ci && npm run dev`.

- Run this [serenity branch](https://gitlab.mx.com/mx/raja/-/merge_requests/8713) and test the following:

    - Click add account
    - Add a manual account
    - After adding a manual account successfully, the drawer should be closed.